### PR TITLE
Remove protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A description of this package.
 
 ## TODO
 
+- Remove PS as an enum to be just a structure
 - Create a real SPS structure, and not just a type alias
 - See the nomenclature of function names. E.g.: notSPS -> not (should be better with the new SPS structure, no more ambiguity)
 - Generalise for not only a couple for set for a PS, but also a MFDD.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A description of this package.
 
 ## TODO
 
-- Remove PS as an enum to be just a structure
 - Create a real SPS structure, and not just a type alias
-- See the nomenclature of function names. E.g.: notSPS -> not (should be better with the new SPS structure, no more ambiguity)
 - Generalise for not only a couple for set for a PS, but also a MFDD.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # PredicateStructure
 
 A description of this package.
+
+## TODO
+
+- Create a real SPS structure, and not just a type alias
+- See the nomenclature of function names. E.g.: notSPS -> not (should be better with the new SPS structure, no more ambiguity)
+- Generalise for not only a couple for set for a PS, but also a MFDD.
+

--- a/Sources/PredicateStructure/CTL.swift
+++ b/Sources/PredicateStructure/CTL.swift
@@ -1,7 +1,7 @@
 /// The Computation tree logic (CTL), is a language to express temporal properties that must hold a model.
 ///  Semantics are often based on Kripke structures. However, the computation here is made on the fly and does not know the whole state space beforehand.
 ///   The strategy is to use the fixpoint to construct this state space, and thanks to monotonicity properties, the computation always finishes.
-///   TODO: Replace all 'let ps = PredicateStructure(ps: .empty, petrinet: petrinet)' by a true structure for SPS to avoid this horrible trick
+///   TODO: Replace all 'let ps = PredicateStructure(ps: .empty, net: net)' by a true structure for SPS to avoid this horrible trick
 indirect enum CTL {
   
   typealias SPS = Set<PS>
@@ -26,52 +26,52 @@ indirect enum CTL {
   case AG(CTL)
   case AU(CTL, CTL)
   
-  func eval(petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
+  func eval(net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
     switch self {
     case .ap(let t):
       return [
-        PS(ps: ([petrinet.inputMarkingForATransition(transition: t)], []), petrinet: petrinet)
+        PS(ps: ([net.inputMarkingForATransition(transition: t)], []), net: net)
       ]
     case .after(let t):
       return [
-        PS(ps:  ([], [petrinet.outputMarkingForATransition(transition: t)]), petrinet: petrinet)
+        PS(ps:  ([], [net.outputMarkingForATransition(transition: t)]), net: net)
       ]
     case .true:
       var dicEmptyMarking: [PlaceType: Int] = [:]
-      for place in petrinet.places {
+      for place in net.places {
         dicEmptyMarking[place] = 0
       }
       return [
-        PS(ps: ([Marking(storage: dicEmptyMarking, petrinet: petrinet)], []), petrinet: petrinet)
+        PS(ps: ([Marking(dicEmptyMarking, net: net)], []), net: net)
       ]
     case .and(let ctl1, let ctl2):
-      return ps.intersection(sps1: ctl1.eval(petrinet: petrinet), sps2: ctl2.eval(petrinet: petrinet))
+      return ps.intersection(sps1: ctl1.eval(net: net), sps2: ctl2.eval(net: net))
     case .not(let ctl1):
-      return ps.not(sps: ctl1.eval(petrinet: petrinet))
+      return ps.not(sps: ctl1.eval(net: net))
     case .EX(let ctl1):
-      return ps.revert(sps: ctl1.eval(petrinet: petrinet))
+      return ps.revert(sps: ctl1.eval(net: net))
     case .AX(let ctl1):
-      return ps.revertTilde(sps: ctl1.eval(petrinet: petrinet))
+      return ps.revertTilde(sps: ctl1.eval(net: net))
     case .EF(let ctl1):
-      return ctl1.evalEF(petrinet: petrinet)
+      return ctl1.evalEF(net: net)
     case .AF(let ctl1):
-      return ctl1.evalAF(petrinet: petrinet)
+      return ctl1.evalAF(net: net)
     case .EG(let ctl1):
-      return ctl1.evalEG(petrinet: petrinet)
+      return ctl1.evalEG(net: net)
     case .AG(let ctl1):
-      return ctl1.evalAG(petrinet: petrinet)
+      return ctl1.evalAG(net: net)
     case .EU(let ctl1, let ctl2):
-      return ctl1.evalEU(ctl: ctl2, petrinet: petrinet)
+      return ctl1.evalEU(ctl: ctl2, net: net)
     case .AU(let ctl1, let ctl2):
-      return ctl1.evalAU(ctl: ctl2, petrinet: petrinet)
+      return ctl1.evalAU(ctl: ctl2, net: net)
     }
     
   }
 
-  func evalEF(petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    var res = self.eval(petrinet: petrinet)
+  func evalEF(net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    var res = self.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res
@@ -80,9 +80,9 @@ indirect enum CTL {
     return res
   }
   
-  func evalAF(petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    var res = self.eval(petrinet: petrinet)
+  func evalAF(net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    var res = self.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res
@@ -97,9 +97,9 @@ indirect enum CTL {
     return res
   }
   
-  func evalEG(petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    var res = self.eval(petrinet: petrinet)
+  func evalEG(net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    var res = self.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res
@@ -114,9 +114,9 @@ indirect enum CTL {
     return res
   }
   
-  func evalAG(petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    var res = self.eval(petrinet: petrinet)
+  func evalAG(net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    var res = self.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res
@@ -125,10 +125,10 @@ indirect enum CTL {
     return res
   }
   
-  func evalEU(ctl: CTL, petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    let phi = self.eval(petrinet: petrinet)
-    var res = ctl.eval(petrinet: petrinet)
+  func evalEU(ctl: CTL, net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    let phi = self.eval(net: net)
+    var res = ctl.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res
@@ -143,10 +143,10 @@ indirect enum CTL {
     return res
   }
   
-  func evalAU(ctl: CTL, petrinet: PN) -> SPS {
-    let ps = PS(ps: nil, petrinet: petrinet)
-    let phi = self.eval(petrinet: petrinet)
-    var res = ctl.eval(petrinet: petrinet)
+  func evalAU(ctl: CTL, net: PN) -> SPS {
+    let ps = PS(ps: nil, net: net)
+    let phi = self.eval(net: net)
+    var res = ctl.eval(net: net)
     var resTemp: SPS = []
     repeat {
       resTemp = res

--- a/Sources/PredicateStructure/CTL.swift
+++ b/Sources/PredicateStructure/CTL.swift
@@ -48,7 +48,7 @@ indirect enum CTL {
     case .and(let ctl1, let ctl2):
       return ps.intersection(sps1: ctl1.eval(petrinet: petrinet), sps2: ctl2.eval(petrinet: petrinet))
     case .not(let ctl1):
-      return ps.notSPS(sps: ctl1.eval(petrinet: petrinet))
+      return ps.not(sps: ctl1.eval(petrinet: petrinet))
     case .EX(let ctl1):
       return ps.revert(sps: ctl1.eval(petrinet: petrinet))
     case .AX(let ctl1):

--- a/Sources/PredicateStructure/CTL.swift
+++ b/Sources/PredicateStructure/CTL.swift
@@ -4,7 +4,7 @@
 ///   TODO: Replace all 'let ps = PredicateStructure(ps: .empty, petrinet: petrinet)' by a true structure for SPS to avoid this horrible trick
 indirect enum CTL {
   
-  typealias SPS = Set<PredicateStructure>
+  typealias SPS = Set<PS>
   typealias PN = PetriNet
   typealias PlaceType = String
   typealias TransitionType = String
@@ -27,15 +27,15 @@ indirect enum CTL {
   case AU(CTL, CTL)
   
   func eval(petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     switch self {
     case .ap(let t):
       return [
-        PredicateStructure(ps: .ps([petrinet.inputMarkingForATransition(transition: t)], []), petrinet: petrinet)
+        PS(ps: ([petrinet.inputMarkingForATransition(transition: t)], []), petrinet: petrinet)
       ]
     case .after(let t):
       return [
-        PredicateStructure(ps:  .ps([], [petrinet.outputMarkingForATransition(transition: t)]), petrinet: petrinet)
+        PS(ps:  ([], [petrinet.outputMarkingForATransition(transition: t)]), petrinet: petrinet)
       ]
     case .true:
       var dicEmptyMarking: [PlaceType: Int] = [:]
@@ -43,7 +43,7 @@ indirect enum CTL {
         dicEmptyMarking[place] = 0
       }
       return [
-        PredicateStructure(ps: .ps([Marking(storage: dicEmptyMarking, petrinet: petrinet)], []), petrinet: petrinet)
+        PS(ps: ([Marking(storage: dicEmptyMarking, petrinet: petrinet)], []), petrinet: petrinet)
       ]
     case .and(let ctl1, let ctl2):
       return ps.intersection(sps1: ctl1.eval(petrinet: petrinet), sps2: ctl2.eval(petrinet: petrinet))
@@ -70,7 +70,7 @@ indirect enum CTL {
   }
 
   func evalEF(petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     var res = self.eval(petrinet: petrinet)
     var resTemp: SPS = []
     repeat {
@@ -81,7 +81,7 @@ indirect enum CTL {
   }
   
   func evalAF(petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     var res = self.eval(petrinet: petrinet)
     var resTemp: SPS = []
     repeat {
@@ -98,7 +98,7 @@ indirect enum CTL {
   }
   
   func evalEG(petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     var res = self.eval(petrinet: petrinet)
     var resTemp: SPS = []
     repeat {
@@ -115,7 +115,7 @@ indirect enum CTL {
   }
   
   func evalAG(petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     var res = self.eval(petrinet: petrinet)
     var resTemp: SPS = []
     repeat {
@@ -126,7 +126,7 @@ indirect enum CTL {
   }
   
   func evalEU(ctl: CTL, petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     let phi = self.eval(petrinet: petrinet)
     var res = ctl.eval(petrinet: petrinet)
     var resTemp: SPS = []
@@ -144,7 +144,7 @@ indirect enum CTL {
   }
   
   func evalAU(ctl: CTL, petrinet: PN) -> SPS {
-    let ps = PredicateStructure(ps: .empty, petrinet: petrinet)
+    let ps = PS(ps: nil, petrinet: petrinet)
     let phi = self.eval(petrinet: petrinet)
     var res = ctl.eval(petrinet: petrinet)
     var resTemp: SPS = []

--- a/Sources/PredicateStructure/Marking.swift
+++ b/Sources/PredicateStructure/Marking.swift
@@ -1,17 +1,14 @@
-/// A marking of a Hero net.
+/// A marking of a Petri net.
 ///
-/// A marking is a mapping that associates the places of a Hero net to the tokens they contain.
+/// A marking is a mapping that associates the places of a Petri net to the tokens they contain.
 ///
-/// An algebra is defined over markings if the type used to represent the tokens associated with
-/// each place (i.e. `PlaceType`) allows it. More specifically, markings are comparable if tokens
-/// are too, and even conform to `AdditiveArithmetic` if tokens do to.
+/// The following example illustrates how to define markings:
 ///
-/// The following example illustrates how to perform arithmetic operations of markings:
-///
-///     let m0: Marking<P> = [.p0: ["1", "2"], .p1: ["4"]]
-///     let m1: Marking<P> = [.p0: ["1", "3"], .p1: ["6"]]
-///     print(m0 + m1)
-///     // Prints "[.p0: ["1", "1", "2", "3"], .p1: ["4", "6"]]"
+///     let net = Petrinet(
+///       places: ["p0", "p1"],
+///       ...
+///     )
+///     let m0 = Marking(["p0": 1, "p1": 4], net: net)
 ///
 public struct Marking {
   
@@ -22,7 +19,8 @@ public struct Marking {
   /// Initializes a marking.
   ///
   /// - Parameters:
-  ///   - mapping: A total map representing this marking.
+  ///   - storage: A mapping representing this marking.
+  ///   - net: The related Petri net
   public init(_ storage: [String: Int], net: PetriNet) {
     var places: Set<String> = []
     for (place, _) in storage {
@@ -39,23 +37,15 @@ public struct Marking {
     return net.places
   }
   
+  /// Allows to  get or set a value of a marking the same way as a dictionnary
+  /// e.g.: marking["p0"] / marking["p0"] = 2
   public subscript(place: String) -> Int? {
     get { return storage[place] }
     set { storage[place] = newValue }
   }
   
-//  public var empty: Marking
 
 }
-
-//extension Marking: ExpressibleByDictionaryLiteral {
-//
-//  public init(dictionaryLiteral elements: (PlaceType, Int)...) {
-//    let mapping = Dictionary(uniqueKeysWithValues: elements)
-//    self.storage = TotalMap(mapping)
-//  }
-//
-//}
 
 extension Marking: Equatable {
   public static func == (lhs: Marking, rhs: Marking) -> Bool {
@@ -72,9 +62,6 @@ extension Marking: Hashable {
 extension Marking: Comparable {
 
   public static func < (lhs: Marking, rhs: Marking) -> Bool {
-//    guard lhs.places == rhs.places else {
-//      fatalError("Both Petri nets used for the comparison are not the same")
-//    }
     for place in lhs.places {
       guard lhs.storage[place]! < rhs.storage[place]! else {
         return false
@@ -111,50 +98,6 @@ extension Marking: Comparable {
   }
   
 }
-
-//extension Marking: AdditiveArithmetic where Int: AdditiveArithmetic {
-//
-////  /// Initializes a marking with a dictionary, associating `Int.zero` for unassigned
-////  /// places.
-////  ///
-////  /// - Parameters:
-////  ///   - mapping: A dictionary representing this marking.
-////  ///
-////  /// The following example illustrates the use of this initializer:
-////  ///
-////  ///     let marking = Marking<P>([.p0: ["42", "1337"], .p1 ["12", "15"])
-////  ///
-////  public init(partial mapping: [PlaceType: Int]) {
-////    self.storage = TotalMap(partial: mapping, defaultValue: .zero)
-////  }
-////
-//  /// A marking in which all places are associated with `Int.zero`.
-//  public static var zero: Marking {
-//    return Marking { _ in Int.zero }
-//  }
-//
-//  public static func + (lhs: Marking, rhs: Marking) -> Marking {
-//    let newStorage = { key in lhs.storage[key] + rhs.storage[key] }
-//    return Marking(storage: newStorage, petrinet: lhs.petrinet)
-//  }
-//
-//  public static func += (lhs: inout Marking, rhs: Marking) {
-//    for place in PlaceType.allCases {
-//      lhs[place] += rhs[place]
-//    }
-//  }
-//
-//  public static func - (lhs: Marking, rhs: Marking) -> Marking {
-//    return Marking { place in lhs[place] - rhs[place] }
-//  }
-//
-//  public static func -= (lhs: inout Marking, rhs: Marking) {
-//    for place in PlaceType.allCases {
-//      lhs[place] -= rhs[place]
-//    }
-//  }
-//
-//}
 
 extension Marking: CustomStringConvertible {
 

--- a/Sources/PredicateStructure/Marking.swift
+++ b/Sources/PredicateStructure/Marking.swift
@@ -17,26 +17,26 @@ public struct Marking {
   
   /// The total map that backs this marking.
   var storage: [String: Int]
-  let petrinet: PetriNet
+  let net: PetriNet
 
   /// Initializes a marking.
   ///
   /// - Parameters:
   ///   - mapping: A total map representing this marking.
-  public init(storage: [String: Int], petrinet: PetriNet) {
+  public init(_ storage: [String: Int], net: PetriNet) {
     var places: Set<String> = []
     for (place, _) in storage {
       places.insert(place)
     }
-    precondition(places == petrinet.places, "Places between the marking and the Petri net do not match.")
+    precondition(places == net.places, "Places between the marking and the Petri net do not match.")
     
     self.storage = storage
-    self.petrinet = petrinet
+    self.net = net
   }
 
   /// A collection containing just the places of the marking.
   public var places: Set<String> {
-    return petrinet.places
+    return net.places
   }
   
   public subscript(place: String) -> Int? {

--- a/Sources/PredicateStructure/Marking.swift
+++ b/Sources/PredicateStructure/Marking.swift
@@ -24,6 +24,12 @@ public struct Marking {
   /// - Parameters:
   ///   - mapping: A total map representing this marking.
   public init(storage: [String: Int], petrinet: PetriNet) {
+    var places: Set<String> = []
+    for (place, _) in storage {
+      places.insert(place)
+    }
+    precondition(places == petrinet.places, "Places between the marking and the Petri net do not match.")
+    
     self.storage = storage
     self.petrinet = petrinet
   }

--- a/Sources/PredicateStructure/PS.swift
+++ b/Sources/PredicateStructure/PS.swift
@@ -516,7 +516,7 @@ extension PS {
       psFirst = spsTemp.first!
       psFirstTemp = psFirst
       spsTemp.remove(psFirst)
-      if let p1 = ps {
+      if let p1 = psFirst.ps {
         let a = p1.inc
         let b = p1.exc
         if b.count <= 1 {

--- a/Sources/PredicateStructure/PSDD.swift
+++ b/Sources/PredicateStructure/PSDD.swift
@@ -1,16 +1,16 @@
-import DDKit
-
-/// A Predicate structure (PS) is a symbolic structure to represent set of markings.
-/// In a formal way, PS is a couple (a,b) ∈ PS, such as a,b ∈ Set<Marking>
-/// A marking that is accepted by such a predicate structure must be included in all markings of "a" and not included in all markings of "b".
-/// e.g.: ({(0,2)}, {(4,5)}).
-/// (0,4), (2, 42), (42, 4) are valid markings, because (0,2) is included but not (4,5)
-/// On the other hand, (0,1), (4,5), (4,42), (42,42) are not valid.
-/// This representation allows to model a potential infinite set of markings in a finite way.
-/// However, for the sake of finite representations and to compute them, we use the Petri net capacity on places to bound them.
-public struct PSDD<PlaceType, TransitionType>: Hashable where PlaceType: Place & Comparable, PlaceType.Content == Int, TransitionType: Transition {
-  
-  typealias SPS = Set<MFDD<PlaceType, Int>>
-  
-  
-}
+//import DDKit
+//
+///// A Predicate structure (PS) is a symbolic structure to represent set of markings.
+///// In a formal way, PS is a couple (a,b) ∈ PS, such as a,b ∈ Set<Marking>
+///// A marking that is accepted by such a predicate structure must be included in all markings of "a" and not included in all markings of "b".
+///// e.g.: ({(0,2)}, {(4,5)}).
+///// (0,4), (2, 42), (42, 4) are valid markings, because (0,2) is included but not (4,5)
+///// On the other hand, (0,1), (4,5), (4,42), (42,42) are not valid.
+///// This representation allows to model a potential infinite set of markings in a finite way.
+///// However, for the sake of finite representations and to compute them, we use the Petri net capacity on places to bound them.
+//public struct PSDD<PlaceType, TransitionType>: Hashable where PlaceType: Place & Comparable, PlaceType.Content == Int, TransitionType: Transition {
+//  
+//  typealias SPS = Set<MFDD<PlaceType, Int>>
+//  
+//  
+//}

--- a/Sources/PredicateStructure/PSDD.swift
+++ b/Sources/PredicateStructure/PSDD.swift
@@ -1,0 +1,16 @@
+import DDKit
+
+/// A Predicate structure (PS) is a symbolic structure to represent set of markings.
+/// In a formal way, PS is a couple (a,b) ∈ PS, such as a,b ∈ Set<Marking>
+/// A marking that is accepted by such a predicate structure must be included in all markings of "a" and not included in all markings of "b".
+/// e.g.: ({(0,2)}, {(4,5)}).
+/// (0,4), (2, 42), (42, 4) are valid markings, because (0,2) is included but not (4,5)
+/// On the other hand, (0,1), (4,5), (4,42), (42,42) are not valid.
+/// This representation allows to model a potential infinite set of markings in a finite way.
+/// However, for the sake of finite representations and to compute them, we use the Petri net capacity on places to bound them.
+public struct PSDD<PlaceType, TransitionType>: Hashable where PlaceType: Place & Comparable, PlaceType.Content == Int, TransitionType: Transition {
+  
+  typealias SPS = Set<MFDD<PlaceType, Int>>
+  
+  
+}

--- a/Sources/PredicateStructure/PetriNet.swift
+++ b/Sources/PredicateStructure/PetriNet.swift
@@ -99,14 +99,14 @@ public class PetriNet
 
   }
 
+  /// Places of the net
   public let places: Set<PlaceType>
+  /// Transitions of the net
   public let transitions: Set<TransitionType>
   /// This net's input matrix.
   public let input: [TransitionType: [PlaceType: ArcLabel]]
-
   /// This net's output matrix.
   public let output: [TransitionType: [PlaceType: ArcLabel]]
-  
   /// The maximum number of tokens inside a place
   public let capacity: [PlaceType: Int]
 
@@ -275,6 +275,7 @@ extension PetriNet {
     return res
   }
   
+  /// Return a marking that contains the minimum amount of tokens in each required place to allow a transition to be fired.
   func inputMarkingForATransition(transition: TransitionType) -> Marking {
     var dicMarking: [PlaceType: Int] = [:]
     for place in places {
@@ -287,6 +288,7 @@ extension PetriNet {
     return Marking(dicMarking, net: self)
   }
   
+  /// Return a marking that contains the exact amount of tokens after a firing of a transition
   func outputMarkingForATransition(transition: TransitionType) -> Marking {
     var dicMarking: [PlaceType: Int] = [:]
     for place in places {
@@ -300,13 +302,3 @@ extension PetriNet {
   }
   
 }
-
-///// A place in a Petri net.
-//public protocol Place: CaseIterable, Hashable {
-//
-//  associatedtype Content: Hashable
-//
-//}
-//
-///// A transition in a Petri net.
-//public protocol Transition: CaseIterable, Hashable {}

--- a/Sources/PredicateStructure/PetriNet.swift
+++ b/Sources/PredicateStructure/PetriNet.swift
@@ -284,7 +284,7 @@ extension PetriNet {
         dicMarking[place] = 0
       }
     }
-    return Marking(storage: dicMarking, petrinet: self)
+    return Marking(dicMarking, net: self)
   }
   
   func outputMarkingForATransition(transition: TransitionType) -> Marking {
@@ -296,7 +296,7 @@ extension PetriNet {
         dicMarking[place] = 0
       }
     }
-    return Marking(storage: dicMarking, petrinet: self)
+    return Marking(dicMarking, net: self)
   }
   
 }

--- a/Sources/PredicateStructure/PetriNet.swift
+++ b/Sources/PredicateStructure/PetriNet.swift
@@ -128,7 +128,14 @@ public class PetriNet
         PetriNet.add(arc: arc, to: &post)
       }
     }
-
+    
+    for (transition, dicPlaceToArc) in pre {
+      precondition(transitions.contains(transition), "All transitions have not been declared in transitions")
+      for (place, _) in dicPlaceToArc {
+        precondition(places.contains(place), "All places have not been declared in places")
+      }
+    }
+    
     self.input = pre
     self.output = post
     if capacity == [:] {
@@ -138,6 +145,7 @@ public class PetriNet
       }
       self.capacity = newCap
     } else {
+      precondition(Set(capacity.keys) == places, "The capacity do not match the required places")
       self.capacity = capacity
     }
   }

--- a/Sources/PredicateStructure/PredicateStructure.swift
+++ b/Sources/PredicateStructure/PredicateStructure.swift
@@ -6,30 +6,37 @@
 /// On the other hand, (0,1), (4,5), (4,42), (42,42) are not valid.
 /// This representation allows to model a potential infinite set of markings in a finite way.
 /// However, for the sake of finite representations and to compute them, we use the Petri net capacity on places to bound them.
-public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, PlaceType.Content == Int, TransitionType: Transition {
+public struct PredicateStructure {
 
-  typealias SPS = Set<PS<PlaceType, TransitionType>>
+  public typealias SPS = Set<PredicateStructure>
+  public typealias PlaceType = String
+  public typealias TransitionType = String
   
-  case empty
-  case ps(Set<Marking<PlaceType>>, Set<Marking<PlaceType>>)
+  public enum PS: Hashable {
+    case empty
+    case ps(Set<Marking>, Set<Marking>)
+  }
+  
+  let ps: PS
+  let petrinet: PetriNet
   
   /// Compute the negation of a predicate structure, which is a set of predicate structures
   /// - Returns: Returns the negation of the predicate structure
   func notPS() -> SPS {
-    switch self {
+    switch ps {
     case .empty:
       var dicMarking: [PlaceType: Int] = [:]
-      for place in PlaceType.allCases {
+      for place in petrinet.places {
         dicMarking[place] = 0
       }
-      return [.ps([Marking(dicMarking)], [])]
+      return [PredicateStructure(ps: .ps([Marking(storage: dicMarking, petrinet: petrinet)], []), petrinet: petrinet)]
     case .ps(let inc, let exc):
       var sps: SPS = []
       for el in inc {
-        sps.insert(.ps([], [el]))
+        sps.insert(PredicateStructure(ps: .ps([], [el]), petrinet: petrinet))
       }
       for el in exc {
-        sps.insert(.ps([el], []))
+        sps.insert(PredicateStructure(ps: .ps([el], []), petrinet: petrinet))
       }
       return sps
     }
@@ -39,61 +46,61 @@ public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, Plac
   /// This is the convergent point such as all marking of markings are included in this convergent marking.
   /// - Parameter markings: The marking set
   /// - Returns: The singleton that contains one marking where each place takes the maximum between all markings.
-  static func convMax(markings: Set<Marking<PlaceType>>) -> Set<Marking<PlaceType>> {
+  func convMax(markings: Set<Marking>) -> Set<Marking> {
     if markings.isEmpty {
       return []
     }
     
-    var markingDic: [PlaceType: Int] = [:]
+    var dicMarking: [PlaceType: Int] = [:]
     for marking in markings {
-      for place in PlaceType.allCases {
-        if let m = markingDic[place] {
-          if m < marking[place] {
-            markingDic[place] = marking[place]
+      for place in petrinet.places {
+        if let m = dicMarking[place] {
+          if m < marking[place]! {
+            dicMarking[place] = marking[place]
           }
         } else {
-          markingDic[place] = marking[place]
+          dicMarking[place] = marking[place]
         }
       }
     }
-    return [Marking(markingDic)]
+    return [Marking(storage: dicMarking, petrinet: petrinet)]
   }
   
   /// convMin, for convergence minimal, is a function to compute a singleton containing a marking where each value is the minimum of all places for a given place.
   /// This is the convergent point such as the convergent marking is included in all the other markings.
   /// - Parameter markings: The marking set
   /// - Returns: The singleton that contains one marking where each place takes the minimum between all markings.
-  static func convMin(markings: Set<Marking<PlaceType>>) -> Set<Marking<PlaceType>> {
+  func convMin(markings: Set<Marking>) -> Set<Marking> {
     if markings.isEmpty {
       return []
     }
     
-    var markingDic: [PlaceType: Int] = [:]
+    var dicMarking: [PlaceType: Int] = [:]
     for marking in markings {
-      for place in PlaceType.allCases {
-        if let m = markingDic[place] {
-          if  marking[place] < m {
-            markingDic[place] = marking[place]
+      for place in petrinet.places {
+        if let m = dicMarking[place] {
+          if marking[place]! < m {
+            dicMarking[place] = marking[place]
           }
         } else {
-          markingDic[place] = marking[place]
+          dicMarking[place] = marking[place]
         }
       }
     }
-    return [Marking(markingDic)]
+    return [Marking(storage: dicMarking, petrinet: petrinet)]
   }
   
   /// minSet for minimum set is a function that removes all markings that could be redundant, i.e. a marking that is already included in another one.
   /// It would mean that the greater marking is already contained in lower one. Thus, we keep only the lowest marking when some of them are included in each other.
   /// - Parameter markings: The marking set
   /// - Returns: The minimal set of markings with no inclusion between all of them.
-  static func minSet(markings: Set<Marking<PlaceType>>) -> Set<Marking<PlaceType>> {
+  func minSet(markings: Set<Marking>) -> Set<Marking> {
     if markings.isEmpty {
       return []
     }
     
     // Extract markings that are included in other ones
-    var invalidMarkings: Set<Marking<PlaceType>> = []
+    var invalidMarkings: Set<Marking> = []
     for marking1 in markings {
       for marking2 in markings {
         if marking1 != marking2 {
@@ -113,47 +120,47 @@ public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, Plac
   /// By canonical form, we mean reducing a in a singleton, removing all possible inclusions in b, and no marking in b included in a.
   /// In addition, when a value of a place in a marking "a" is greater than one of "b", the value of "b" marking is changed to the value of "a".
   /// - Returns: The canonical form of the predicate structure.
-  func canPS() -> PS {
-    switch self {
+  func canPS() -> PredicateStructure {
+    switch ps {
     case .empty:
-      return .empty
+      return PredicateStructure(ps: .empty, petrinet: petrinet)
     case .ps(let inc, let exc):
-      let canInclude = PS.convMax(markings: inc)
-      let preCanExclude = PS.minSet(markings: exc)
+      let canInclude = convMax(markings: inc)
+      let preCanExclude = minSet(markings: exc)
             
       if let markingInclude = canInclude.first {
         // In (a,b) ∈ PS, if a marking in b is included in a, it returns empty
         for marking in preCanExclude {
           if marking <= markingInclude {
-            return .empty
+            return PredicateStructure(ps: .empty, petrinet: petrinet)
           }
         }
         
         // In ({q},b) ∈ PS, forall q_b in b, if q(p) >= q_b(p) => q_b(p) = q(p)
-        var canExclude: Set<Marking<PlaceType>> = []
-        var markingTemp: Marking<PlaceType>
+        var canExclude: Set<Marking> = []
+        var markingTemp: Marking
         for marking in preCanExclude {
           markingTemp = marking
-          for place in PlaceType.allCases {
-            if markingTemp[place] < markingInclude[place] {
+          for place in petrinet.places {
+            if markingTemp[place]! < markingInclude[place]! {
               markingTemp[place] = markingInclude[place]
             }
           }
           canExclude.insert(markingTemp)
         }
         if canInclude.isEmpty && canExclude.isEmpty {
-          return .empty
+          return PredicateStructure(ps: .empty, petrinet: petrinet)
         }
-        return .ps(canInclude, canExclude)
+        return PredicateStructure(ps: .ps(canInclude, canExclude), petrinet: petrinet)
       }
-      return .ps([], preCanExclude)
+      return PredicateStructure(ps: .ps([], preCanExclude), petrinet: petrinet)
     }
   }
   
   /// Compute all the markings represented by the symbolic representation of a predicate structure.
   /// - Parameter petrinet: The model to use
   /// - Returns: The set of all possible markings, also known as the state space.
-  func underlyingMarkings(petrinet: PetriNet<PlaceType, TransitionType>) -> Set<Marking<PlaceType>> {
+  func underlyingMarkings() -> Set<Marking> {
     let canonizedPS = self.canPS()
     var placeSetValues: [PlaceType: Set<Int>] = [:]
     var res: Set<[PlaceType: Int]> = []
@@ -162,13 +169,13 @@ public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, Plac
     var upperBound: Int
     
     // Create a dictionnary where the key is the place and whose values is a set of all possibles integers that can be taken
-    switch canonizedPS {
+    switch canonizedPS.ps {
     case .empty:
       return []
     case .ps(let a, _):
       if let am = a.first {
-        for place in PlaceType.allCases {
-          lowerBound = am[place]
+        for place in petrinet.places {
+          lowerBound = am[place]!
           upperBound = petrinet.capacity[place]!
           for i in lowerBound ..< upperBound+1 {
             if let _ = placeSetValues[place] {
@@ -204,11 +211,11 @@ public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, Plac
     }
     
     // Convert all dictionnaries into markings
-    var markingSet: Set<Marking<PlaceType>> = Set(res.map({(el: [PlaceType: Int]) -> Marking<PlaceType> in
-      Marking<PlaceType>(el)
+    var markingSet: Set<Marking> = Set(res.map({(el: [PlaceType: Int]) -> Marking in
+      Marking(storage: el, petrinet: petrinet)
     }))
     
-    switch canonizedPS {
+    switch canonizedPS.ps {
     case .ps(_, let b):
       for mb in b {
         for marking in markingSet {
@@ -228,44 +235,53 @@ public enum PS<PlaceType, TransitionType>: Hashable where PlaceType: Place, Plac
   /// Encode a marking into a predicate structure. This predicate structure encodes a singe marking.
   /// - Parameter marking: The marking to encode
   /// - Returns: The predicate structure that represents the marking
-  static func encodeMarking(_ marking: Marking<PlaceType>) -> PS {
-    var bMarkings: Set<Marking<PlaceType>> = []
+  func encodeMarking(_ marking: Marking) -> PredicateStructure {
+    var bMarkings: Set<Marking> = []
     var markingTemp = marking
-    for place in PlaceType.allCases {
-      markingTemp[place] += 1
+    for place in petrinet.places {
+      markingTemp[place]! += 1
       bMarkings.insert(markingTemp)
       markingTemp = marking
     }
     
-    return .ps([marking], bMarkings)
+    return PredicateStructure(ps: .ps([marking], bMarkings), petrinet: petrinet)
   }
   
   /// Encode a set of markings into a set of predicate structures.
   /// - Parameter markingSet: The marking set to encode
   /// - Returns: A set of predicate structures that encodes the set of markings
-  static func encodeMarkingSet(_ markingSet: Set<Marking<PlaceType>>) -> SPS {
+  func encodeMarkingSet(_ markingSet: Set<Marking>) -> SPS {
     var sps: SPS = []
     for marking in markingSet {
       sps.insert(encodeMarking(marking))
     }
-    return PS.simplifiedSPS(sps: sps)
+    return simplifiedSPS(sps: sps)
   }
 
+}
+
+extension PredicateStructure: Hashable {
+  public static func == (lhs: PredicateStructure, rhs: PredicateStructure) -> Bool {
+    return lhs.ps == rhs.ps
+  }
   
+  public func hash(into hasher: inout Hasher) {
+      hasher.combine(ps)
+  }
 }
 
 // Functions that takes SPS as input
-extension PS {
+extension PredicateStructure {
   
   /// Apply the union between two sets of predicate structures. Almost the same as set union, except we remove the predicate structure empty if there is one.
   /// - Parameters:
   ///   - s1: The first set of predicate structures
   ///   - s2: The first set of predicate structures
   /// - Returns: The result of the union.
-  static func union(sps1: SPS, sps2: SPS) -> SPS {
+  func union(sps1: SPS, sps2: SPS) -> SPS {
     var union = sps1.union(sps2)
-    if union.contains(.empty) {
-      union.remove(.empty)
+    if union.contains(PredicateStructure(ps: .empty, petrinet: petrinet)) {
+      union.remove(PredicateStructure(ps: .empty, petrinet: petrinet))
     }
     return union
   }
@@ -276,35 +292,33 @@ extension PS {
   ///   - s2: The second set of predicate structures
   ///   - isCanonical: An option to decide whether the application simplifies each new predicate structure into its canonical form. The intersection can create contradiction that leads to empty predicate structure or simplification. It is true by default, but it can be changed as false.
   /// - Returns: The result of the intersection.
-  static func intersection(sps1: SPS, sps2: SPS, isCanonical: Bool = true) -> SPS {
+  func intersection(sps1: SPS, sps2: SPS, isCanonical: Bool = true) -> SPS {
     var res: SPS = []
-    var temp: PS
+    var temp: PredicateStructure
     for ps1 in sps1 {
       for ps2 in sps2 {
-        switch (ps1, ps2) {
+        switch (ps1.ps, ps2.ps) {
         case (.empty, _):
           break
         case (_, .empty):
           break
         case (.ps(let inc1, let exc1), .ps(let inc2, let exc2)):
+          let intersectRaw = PredicateStructure(ps: PS.ps(inc1.union(inc2), exc1.union(exc2)), petrinet: petrinet)
           if isCanonical {
-            temp = PS.ps(inc1.union(inc2), exc1.union(exc2)).canPS()
-            switch temp {
+            temp = intersectRaw.canPS()
+            switch temp.ps {
             case .empty:
               break
             default:
-              res.insert(
-                (PS.ps(inc1.union(inc2), exc1.union(exc2))).canPS()
-              )
+              res.insert(temp)
             }
           } else {
-            res.insert(
-              .ps(inc1.union(inc2), exc1.union(exc2))
-            )
+            res.insert(intersectRaw)
           }
         }
       }
     }
+
     return res
   }
   
@@ -312,7 +326,7 @@ extension PS {
   /// Compute the negation of a set of predicate structures. This is the result of a combination of all elements inside a predicate structure with each element of the other predicate structures. E.g.: notSPS({([q1], [q2]), ([q3], [q4]), ([q5], [q6])}) = {([],[q1,q3,q5]), ([q6],[q1,q3]), ([q4],[q1,q5]), ([q4,q6],[q1]), ([q2],[q3,q5]), ([q2, q6],[q3]), ([q2, q4],[q5]), ([q2, q4,q6],[])}
   /// - Parameter sps: The set of predicate structures
   /// - Returns: The negation of the set of predicate structures
-  static func notSPS(sps: SPS) -> SPS {
+  func notSPS(sps: SPS) -> SPS {
     if sps.isEmpty {
       return []
     }
@@ -335,18 +349,19 @@ extension PS {
   ///   - ps: The predicate structure
   ///   - sps: The set of predicate structures
   /// - Returns: The product between both parameters
-  static func distribute(ps: PS, sps: SPS) -> SPS {
+  func distribute(ps: PredicateStructure, sps: SPS) -> SPS {
     if let first = sps.first {
-      switch ps {
+      switch ps.ps {
       case .empty:
         return []
-      case let ps:
+      case let p:
+        let ps1 = PredicateStructure(ps: p, petrinet: petrinet)
         var rest = sps
         rest.remove(first)
         if rest == [] {
-          return intersection(sps1: [ps], sps2: [first])
+          return intersection(sps1: [ps1], sps2: [first])
         }
-        return intersection(sps1: [ps], sps2: [first]).union(distribute(ps: ps, sps: rest))
+        return intersection(sps1: [ps1], sps2: [first]).union(distribute(ps: ps1, sps: rest))
       }
     }
     return [ps]
@@ -358,7 +373,7 @@ extension PS {
   ///   - s1: The left set of predicate structures
   ///   - s2: The right set of predicate structures
   /// - Returns: True if it is included, false otherwise
-  static func isIncluded(sps1: SPS, sps2: SPS) -> Bool {
+  func isIncluded(sps1: SPS, sps2: SPS) -> Bool {
     if sps2 == [] {
       if sps1 == [] {
         return true
@@ -373,21 +388,21 @@ extension PS {
   ///   - s1: First set of predicate structures
   ///   - s2: Second set of predicate structures
   /// - Returns: True is they are equivalentm false otherwise
-  static func equiv(sps1: SPS, sps2: SPS) -> Bool {
+  func equiv(sps1: SPS, sps2: SPS) -> Bool {
     return isIncluded(sps1: sps1, sps2: sps2) && isIncluded(sps1: sps2, sps2: sps1)
   }
   
-  static func isIn(ps: PS, sps: SPS) -> Bool {
+  func isIn(ps: PredicateStructure, sps: SPS) -> Bool {
     return isIncluded(sps1: [ps], sps2: sps)
   }
   
-  static func revert(ps: PS, transition: TransitionType, petrinet: PetriNet<PlaceType, TransitionType>) -> PS? {
-    switch ps {
+  func revert(ps: PredicateStructure, transition: TransitionType) -> PredicateStructure? {
+    switch ps.ps {
     case .empty:
-      return .empty
+      return PredicateStructure(ps: .empty, petrinet: petrinet)
     case .ps(let a, let b):
-      var aTemp: Set<Marking<PlaceType>> = []
-      var bTemp: Set<Marking<PlaceType>> = []
+      var aTemp: Set<Marking> = []
+      var bTemp: Set<Marking> = []
       
       if a == [] {
         aTemp = [petrinet.inputMarkingForATransition(transition: transition)]
@@ -409,31 +424,31 @@ extension PS {
           }
         }
       }
-      return .ps(aTemp, bTemp)
+      return PredicateStructure(ps: .ps(aTemp, bTemp), petrinet: petrinet)
     }
 
   }
   
-  static func revert(ps: PS, petrinet: PetriNet<PlaceType, TransitionType>) -> SPS {
+  func revert(ps: PredicateStructure) -> SPS {
     var res: SPS = []
-    for transition in TransitionType.allCases {
-      if let rev = revert(ps: ps, transition: transition, petrinet: petrinet) {
+    for transition in petrinet.transitions {
+      if let rev = revert(ps: ps, transition: transition) {
         res.insert(rev)
       }
     }
     return res
   }
   
-  static func revert(sps: SPS, petrinet: PetriNet<PlaceType, TransitionType>) -> SPS {
+  func revert(sps: SPS) -> SPS {
     var res: SPS = []
     for ps in sps {
-      res = res.union(revert(ps: ps, petrinet: petrinet))
+      res = res.union(revert(ps: ps))
     }
     return res
   }
   
-  static func revertTilde(sps: SPS, petrinet: PetriNet<PlaceType, TransitionType>) -> SPS {
-    return notSPS(sps: PS.revert(sps: PS.notSPS(sps: sps), petrinet: petrinet))
+  func revertTilde(sps: SPS) -> SPS {
+    return notSPS(sps: revert(sps: notSPS(sps: sps)))
   }
   
   
@@ -444,11 +459,11 @@ extension PS {
   ///   - ps1: The first predicate structure
   ///   - ps2: The second predicate structure
   /// - Returns: The result of the merged. If this is not possible, returns the original predicate structures.
-  static func merge(ps1: PS, ps2: PS) -> SPS {
+  func merge(ps1: PredicateStructure, ps2: PredicateStructure) -> SPS {
     var ps1Temp = ps1
     var ps2Temp = ps2
     
-    switch (ps1, ps2) {
+    switch (ps1.ps, ps2.ps) {
     case (.ps(let a, _), .ps(let c, _)):
       if let am = a.first, let cm = c.first  {
         if !(am <= cm) {
@@ -460,22 +475,22 @@ extension PS {
       return [ps1,ps2]
     }
     
-    switch (ps1Temp, ps2Temp) {
+    switch (ps1Temp.ps, ps2Temp.ps) {
     case (.ps(let a, let b), .ps(let c, let d)):
       if let am = a.first, let cm = c.first {
         if let bm = b.first {
           if cm <= bm && am <= cm {
             if let dm = d.first {
               if bm <= dm {
-                return [.ps(a,d)]
+                return [.init(ps: .ps(a,d), petrinet: petrinet)]
               }
-              return [.ps(a,b)]
+              return [.init(ps: .ps(a,b), petrinet: petrinet)]
             }
-            return [.ps(a,d)]
+            return [.init(ps: .ps(a,d), petrinet: petrinet)]
           }
         }
         if am <= cm {
-          return [.ps(a,b)]
+          return [.init(ps: .ps(a,b), petrinet: petrinet)]
         }
       }
     default:
@@ -497,12 +512,12 @@ extension PS {
   /// {([(p0: 1, p1: 2, p2: 0)], [(p0: 1, p1: 2, p2: 1)]), ([(p0: 0, p1: 2, p2: 1)], [])}
   /// - Parameter sps: The set of predicate structures to simplify
   /// - Returns: The simplified version of the sps.
-  static func simplifiedSPS(sps: SPS) -> SPS {
+  func simplifiedSPS(sps: SPS) -> SPS {
     var mergedSPS: SPS = []
     var mergedTemp: SPS = []
     var spsTemp: SPS = []
-    var psFirst: PS = .empty
-    var psFirstTemp: PS = .empty
+    var psFirst: PredicateStructure = .init(ps: .empty, petrinet: petrinet)
+    var psFirstTemp: PredicateStructure = .init(ps: .empty, petrinet: petrinet)
     
     for ps in sps {
       spsTemp.insert(ps.canPS())
@@ -516,29 +531,29 @@ extension PS {
       psFirst = spsTemp.first!
       psFirstTemp = psFirst
       spsTemp.remove(psFirst)
-      switch psFirst {
+      switch psFirst.ps {
       case .ps(let a, let b):
         if b.count <= 1 {
           for ps in spsTemp {
-            switch ps {
+            switch ps.ps {
             case .ps(let c, let d):
               if d.count <= 1 {
                 if let am = a.first, let bm = b.first, let cm = c.first {
                   if cm <= bm && am <= cm {
-                    mergedTemp = merge(ps1: psFirstTemp, ps2: .ps(c, d))
+                    mergedTemp = merge(ps1: psFirstTemp, ps2: .init(ps: .ps(c, d), petrinet: petrinet))
                     if mergedTemp.count == 1 {
-                      psFirstTemp = merge(ps1: psFirstTemp, ps2: .ps(c, d)).first!
-                      spsTemp.remove(.ps(c, d))
+                      psFirstTemp = merge(ps1: psFirstTemp, ps2: .init(ps: .ps(c, d), petrinet: petrinet)).first!
+                      spsTemp.remove(.init(ps: .ps(c, d), petrinet: petrinet))
                       spsTemp.insert(psFirstTemp)
                     }
                   }
                 } else {
                   if let am = a.first, let cm = c.first, let dm = d.first {
                     if am <= dm && cm <= am {
-                      mergedTemp = merge(ps1: psFirstTemp, ps2: .ps(c, d))
+                      mergedTemp = merge(ps1: psFirstTemp, ps2: .init(ps: .ps(c, d), petrinet: petrinet))
                       if mergedTemp.count == 1 {
-                        psFirstTemp = merge(ps1: psFirstTemp, ps2: .ps(c, d)).first!
-                        spsTemp.remove(.ps(c, d))
+                        psFirstTemp = merge(ps1: psFirstTemp, ps2: .init(ps: .ps(c, d), petrinet: petrinet)).first!
+                        spsTemp.remove(.init(ps: .ps(c, d), petrinet: petrinet))
                         spsTemp.insert(psFirstTemp)
                       }
                     }
@@ -559,7 +574,7 @@ extension PS {
     var reducedSPS: SPS = []
     
     for ps in mergedSPS {
-      if !PS.isIncluded(sps1: [ps], sps2: mergedSPS.filter({!($0 == ps)})) {
+      if !isIncluded(sps1: [ps], sps2: mergedSPS.filter({!($0 == ps)})) {
         reducedSPS.insert(ps)
       }
     }
@@ -568,9 +583,9 @@ extension PS {
   
 }
 
-extension PS: CustomStringConvertible {
+extension PredicateStructure: CustomStringConvertible {
   public var description: String {
-    switch self {
+    switch self.ps {
     case .empty:
       return "∅"
     case .ps(let inc, let exc):

--- a/Tests/PredicateStructureTests/CTLTests.swift
+++ b/Tests/PredicateStructureTests/CTLTests.swift
@@ -1,232 +1,232 @@
-import XCTest
-@testable import PredicateStructure
-
-final class CTLTests: XCTestCase {
-  
-  func testCTLEvalAX() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1,p2
-    }
-
-    enum T: Transition {
-      case t0,t1,t2,t3
-    }
-
-    // Following Petri net:
-    //          t0   p2   t3
-    //       -> ▭ -> o -> ▭
-    // p0  /
-    // o -
-    //     \
-    //       -> ▭ -> o -> ▭
-    //          t1   p1   t2
-    let pn = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 1),
-      .post(from: .t0, to: .p2, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 1),
-      .post(from: .t1, to: .p1, labeled: 1),
-      .pre(from: .p2, to: .t3, labeled: 1),
-      .pre(from: .p1, to: .t2, labeled: 1)
-    )
-    
-    let ps1: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 1])], [])
-    let ps2: PS<P,T> = .ps([], [Marking([.p0: 1, .p1: 0, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 0, .p2: 1])])
-    let ps3: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 1])])
-    let ps4: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 1])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
-    let ps5: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
-    
-    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5]
-    
-    let ctlFormula: CTL<P,T> = .AX(.ap(.t2))
-    let sps = ctlFormula.eval(petrinet: pn)
-    let simpliedSPS = PS.simplifiedSPS(sps: sps)
-
-    XCTAssertTrue(PS.equiv(sps1: simpliedSPS, sps2: expectedSPS))
-  }
-
-  
-  func testCTLEvalEF() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p1,p2,p3,p4,p5
-    }
-
-    enum T: Transition {
-      case t1,t2,t4,t5
-    }
-
-    // Petri net that models the mutual exclusion problem
-    let pn = PetriNet<P, T>(
-      .pre(from: .p1, to: .t1, labeled: 1),
-      .pre(from: .p3, to: .t1, labeled: 1),
-      .post(from: .t1, to: .p4, labeled: 1),
-      .pre(from: .p2, to: .t2, labeled: 1),
-      .pre(from: .p3, to: .t2, labeled: 1),
-      .post(from: .t2, to: .p5, labeled: 1),
-      .pre(from: .p4, to: .t4, labeled: 1),
-      .post(from: .t4, to: .p1, labeled: 1),
-      .post(from: .t4, to: .p3, labeled: 1),
-      .pre(from: .p5, to: .t5, labeled: 1),
-      .post(from: .t5, to: .p2, labeled: 1),
-      .post(from: .t5, to: .p3, labeled: 1)
-    )
-    
-    let ps1: PS<P,T> = .ps([Marking([.p1: 0, .p2: 0, .p3: 0, .p4: 1, .p5: 1])], [])
-    let ps2: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 1, .p4: 1, .p5: 0])], [])
-    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 1, .p4: 0, .p5: 1])], [])
-    let ps4: PS<P,T> = .ps([Marking([.p1: 1, .p2: 1, .p3: 2, .p4: 0, .p5: 0])], [])
-    let ps5: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 0, .p4: 2, .p5: 0])], [])
-    let ps6: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 0, .p4: 0, .p5: 2])], [])
-    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5, ps6]
-    
-    // Compute all markings that breaks the mutual exclusion
-    let ctlFormula: CTL<P,T> = .EF(.and(.ap(.t4), .ap(.t5)))
-    let sps = ctlFormula.eval(petrinet: pn)
-    
-    XCTAssertEqual(expectedSPS, PS.simplifiedSPS(sps: sps))
-  }
-  
-  // No answers for EG/AG
-  func testCTLEval1() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1
-    }
-
-    enum T: Transition {
-      case t0,t1,t2
-    }
-
-    // Following Petri net:
-    //          t0
-    //       -> ▭
-    // p0  /
-    // o -
-    //     \
-    //       -> ▭ -> o -> ▭
-    //          t1   p1   t2
-    let pn = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 1),
-      .post(from: .t1, to: .p1, labeled: 1),
-      .pre(from: .p1, to: .t2, labeled: 1),
-      capacity: [.p0: 4, .p1: 4]
-    )
-    
-    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
-    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
-    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
-    let sps1 = ctlFormula1.eval(petrinet: pn)
-    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-    let sps2 = ctlFormula2.eval(petrinet: pn)
-    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-    let sps3 = ctlFormula3.eval(petrinet: pn)
-    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-    
-    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
-    let expectedRes: Set<PS<P,T>> = [ps]
-    
-    XCTAssertEqual(simpliedSPS1, expectedRes)
-    XCTAssertEqual(simpliedSPS2, [])
-    XCTAssertEqual(simpliedSPS3, [])
-  }
-  
-  func testCTLEval2() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1
-    }
-
-    enum T: Transition {
-      case t0,t1,t2
-    }
-
-    // Following Petri net:
-    //          t0
-    //       -> ▭
-    // p0  /
-    // o -
-    //     \
-    //       -> ▭ -> o <-> ▭
-    //          t1   p1   t2
-    let pn = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 1),
-      .post(from: .t1, to: .p1, labeled: 1),
-      .pre(from: .p1, to: .t2, labeled: 1),
-      .post(from: .t2, to: .p1, labeled: 1)
-    )
-    
-    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
-    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
-    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
-    let sps1 = ctlFormula1.eval(petrinet: pn)
-    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-    let sps2 = ctlFormula2.eval(petrinet: pn)
-    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-    let sps3 = ctlFormula3.eval(petrinet: pn)
-    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-    
-    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
-    let expectedRes: Set<PS<P,T>> = [ps]
-    
-    XCTAssertEqual(simpliedSPS1, expectedRes)
-    XCTAssertEqual(simpliedSPS2, expectedRes)
-    XCTAssertEqual(simpliedSPS3, expectedRes)
-  }
-  
-  func testCTLEval3() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1,p2
-    }
-
-    enum T: Transition {
-      case t0,t1
-    }
-
-    // Following Petri net:
-    // p1
-    //       2 t1
-    //      <--
-    // p0 o     ▭ --> o p1
-    //    | -->
-    //    |  5
-    //    |
-    //    |
-    //     -->  ▭ --> o p2
-    //      7   t0
-    let pn = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 7),
-      .post(from: .t0, to: .p2, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 2),
-      .post(from: .t1, to: .p0, labeled: 5),
-      .post(from: .t1, to: .p1, labeled: 1)
-    )
-    
-    let ctlFormula1: CTL<P,T> = .AX(.and(.ap(.t1), .not(.ap(.t0))))
-    let ctlFormula2: CTL<P,T> = .EU(.ap(.t1), .ap(.t0))
-    let ctlFormula3: CTL<P,T> = .AU(.ap(.t1), .ap(.t0))
-    let sps1 = ctlFormula1.eval(petrinet: pn)
-    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-    let sps2 = ctlFormula2.eval(petrinet: pn)
-    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-    let sps3 = ctlFormula3.eval(petrinet: pn)
-    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-    
-    let ps1: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [])
-    let ps2: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [Marking([.p0: 4, .p1: 0, .p2: 0])])
-    let ps3: PS<P,T> = .ps([], [Marking([.p0: 2, .p1: 0, .p2: 0])])
-    
-    XCTAssertEqual(simpliedSPS1, [ps2,ps3])
-    XCTAssertEqual(simpliedSPS2, [ps1])
-    XCTAssertEqual(simpliedSPS3, [ps1])
-  }
-  
-}
+//import XCTest
+//@testable import PredicateStructure
+//
+//final class CTLTests: XCTestCase {
+//  
+//  func testCTLEvalAX() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1,p2
+//    }
+//
+//    enum T: Transition {
+//      case t0,t1,t2,t3
+//    }
+//
+//    // Following Petri net:
+//    //          t0   p2   t3
+//    //       -> ▭ -> o -> ▭
+//    // p0  /
+//    // o -
+//    //     \
+//    //       -> ▭ -> o -> ▭
+//    //          t1   p1   t2
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 1),
+//      .post(from: .t0, to: .p2, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 1),
+//      .post(from: .t1, to: .p1, labeled: 1),
+//      .pre(from: .p2, to: .t3, labeled: 1),
+//      .pre(from: .p1, to: .t2, labeled: 1)
+//    )
+//    
+//    let ps1: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 1])], [])
+//    let ps2: PS<P,T> = .ps([], [Marking([.p0: 1, .p1: 0, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 0, .p2: 1])])
+//    let ps3: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 1])])
+//    let ps4: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 1])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
+//    let ps5: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
+//    
+//    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5]
+//    
+//    let ctlFormula: CTL<P,T> = .AX(.ap(.t2))
+//    let sps = ctlFormula.eval(petrinet: pn)
+//    let simpliedSPS = PS.simplifiedSPS(sps: sps)
+//
+//    XCTAssertTrue(PS.equiv(sps1: simpliedSPS, sps2: expectedSPS))
+//  }
+//
+//  
+//  func testCTLEvalEF() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p1,p2,p3,p4,p5
+//    }
+//
+//    enum T: Transition {
+//      case t1,t2,t4,t5
+//    }
+//
+//    // Petri net that models the mutual exclusion problem
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p1, to: .t1, labeled: 1),
+//      .pre(from: .p3, to: .t1, labeled: 1),
+//      .post(from: .t1, to: .p4, labeled: 1),
+//      .pre(from: .p2, to: .t2, labeled: 1),
+//      .pre(from: .p3, to: .t2, labeled: 1),
+//      .post(from: .t2, to: .p5, labeled: 1),
+//      .pre(from: .p4, to: .t4, labeled: 1),
+//      .post(from: .t4, to: .p1, labeled: 1),
+//      .post(from: .t4, to: .p3, labeled: 1),
+//      .pre(from: .p5, to: .t5, labeled: 1),
+//      .post(from: .t5, to: .p2, labeled: 1),
+//      .post(from: .t5, to: .p3, labeled: 1)
+//    )
+//    
+//    let ps1: PS<P,T> = .ps([Marking([.p1: 0, .p2: 0, .p3: 0, .p4: 1, .p5: 1])], [])
+//    let ps2: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 1, .p4: 1, .p5: 0])], [])
+//    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 1, .p4: 0, .p5: 1])], [])
+//    let ps4: PS<P,T> = .ps([Marking([.p1: 1, .p2: 1, .p3: 2, .p4: 0, .p5: 0])], [])
+//    let ps5: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 0, .p4: 2, .p5: 0])], [])
+//    let ps6: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 0, .p4: 0, .p5: 2])], [])
+//    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5, ps6]
+//    
+//    // Compute all markings that breaks the mutual exclusion
+//    let ctlFormula: CTL<P,T> = .EF(.and(.ap(.t4), .ap(.t5)))
+//    let sps = ctlFormula.eval(petrinet: pn)
+//    
+//    XCTAssertEqual(expectedSPS, PS.simplifiedSPS(sps: sps))
+//  }
+//  
+//  // No answers for EG/AG
+//  func testCTLEval1() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1
+//    }
+//
+//    enum T: Transition {
+//      case t0,t1,t2
+//    }
+//
+//    // Following Petri net:
+//    //          t0
+//    //       -> ▭
+//    // p0  /
+//    // o -
+//    //     \
+//    //       -> ▭ -> o -> ▭
+//    //          t1   p1   t2
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 1),
+//      .post(from: .t1, to: .p1, labeled: 1),
+//      .pre(from: .p1, to: .t2, labeled: 1),
+//      capacity: [.p0: 4, .p1: 4]
+//    )
+//    
+//    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
+//    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
+//    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
+//    let sps1 = ctlFormula1.eval(petrinet: pn)
+//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
+//    let sps2 = ctlFormula2.eval(petrinet: pn)
+//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
+//    let sps3 = ctlFormula3.eval(petrinet: pn)
+//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
+//    
+//    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
+//    let expectedRes: Set<PS<P,T>> = [ps]
+//    
+//    XCTAssertEqual(simpliedSPS1, expectedRes)
+//    XCTAssertEqual(simpliedSPS2, [])
+//    XCTAssertEqual(simpliedSPS3, [])
+//  }
+//  
+//  func testCTLEval2() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1
+//    }
+//
+//    enum T: Transition {
+//      case t0,t1,t2
+//    }
+//
+//    // Following Petri net:
+//    //          t0
+//    //       -> ▭
+//    // p0  /
+//    // o -
+//    //     \
+//    //       -> ▭ -> o <-> ▭
+//    //          t1   p1   t2
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 1),
+//      .post(from: .t1, to: .p1, labeled: 1),
+//      .pre(from: .p1, to: .t2, labeled: 1),
+//      .post(from: .t2, to: .p1, labeled: 1)
+//    )
+//    
+//    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
+//    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
+//    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
+//    let sps1 = ctlFormula1.eval(petrinet: pn)
+//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
+//    let sps2 = ctlFormula2.eval(petrinet: pn)
+//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
+//    let sps3 = ctlFormula3.eval(petrinet: pn)
+//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
+//    
+//    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
+//    let expectedRes: Set<PS<P,T>> = [ps]
+//    
+//    XCTAssertEqual(simpliedSPS1, expectedRes)
+//    XCTAssertEqual(simpliedSPS2, expectedRes)
+//    XCTAssertEqual(simpliedSPS3, expectedRes)
+//  }
+//  
+//  func testCTLEval3() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1,p2
+//    }
+//
+//    enum T: Transition {
+//      case t0,t1
+//    }
+//
+//    // Following Petri net:
+//    // p1
+//    //       2 t1
+//    //      <--
+//    // p0 o     ▭ --> o p1
+//    //    | -->
+//    //    |  5
+//    //    |
+//    //    |
+//    //     -->  ▭ --> o p2
+//    //      7   t0
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 7),
+//      .post(from: .t0, to: .p2, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 2),
+//      .post(from: .t1, to: .p0, labeled: 5),
+//      .post(from: .t1, to: .p1, labeled: 1)
+//    )
+//    
+//    let ctlFormula1: CTL<P,T> = .AX(.and(.ap(.t1), .not(.ap(.t0))))
+//    let ctlFormula2: CTL<P,T> = .EU(.ap(.t1), .ap(.t0))
+//    let ctlFormula3: CTL<P,T> = .AU(.ap(.t1), .ap(.t0))
+//    let sps1 = ctlFormula1.eval(petrinet: pn)
+//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
+//    let sps2 = ctlFormula2.eval(petrinet: pn)
+//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
+//    let sps3 = ctlFormula3.eval(petrinet: pn)
+//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
+//    
+//    let ps1: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [])
+//    let ps2: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [Marking([.p0: 4, .p1: 0, .p2: 0])])
+//    let ps3: PS<P,T> = .ps([], [Marking([.p0: 2, .p1: 0, .p2: 0])])
+//    
+//    XCTAssertEqual(simpliedSPS1, [ps2,ps3])
+//    XCTAssertEqual(simpliedSPS2, [ps1])
+//    XCTAssertEqual(simpliedSPS3, [ps1])
+//  }
+//  
+//}

--- a/Tests/PredicateStructureTests/CTLTests.swift
+++ b/Tests/PredicateStructureTests/CTLTests.swift
@@ -1,232 +1,200 @@
-//import XCTest
-//@testable import PredicateStructure
-//
-//final class CTLTests: XCTestCase {
-//  
-//  func testCTLEvalAX() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1,p2
-//    }
-//
-//    enum T: Transition {
-//      case t0,t1,t2,t3
-//    }
-//
-//    // Following Petri net:
-//    //          t0   p2   t3
-//    //       -> ▭ -> o -> ▭
-//    // p0  /
-//    // o -
-//    //     \
-//    //       -> ▭ -> o -> ▭
-//    //          t1   p1   t2
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 1),
-//      .post(from: .t0, to: .p2, labeled: 1),
-//      .pre(from: .p0, to: .t1, labeled: 1),
-//      .post(from: .t1, to: .p1, labeled: 1),
-//      .pre(from: .p2, to: .t3, labeled: 1),
-//      .pre(from: .p1, to: .t2, labeled: 1)
-//    )
-//    
-//    let ps1: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 1])], [])
-//    let ps2: PS<P,T> = .ps([], [Marking([.p0: 1, .p1: 0, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 0, .p2: 1])])
-//    let ps3: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 1])])
-//    let ps4: PS<P,T> = .ps([Marking([.p0: 0, .p1: 2, .p2: 1])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
-//    let ps5: PS<P,T> = .ps([Marking([.p0: 1, .p1: 2, .p2: 0])], [Marking([.p0: 1, .p1: 2, .p2: 1])])
-//    
-//    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5]
-//    
-//    let ctlFormula: CTL<P,T> = .AX(.ap(.t2))
-//    let sps = ctlFormula.eval(petrinet: pn)
-//    let simpliedSPS = PS.simplifiedSPS(sps: sps)
-//
-//    XCTAssertTrue(PS.equiv(sps1: simpliedSPS, sps2: expectedSPS))
-//  }
-//
-//  
-//  func testCTLEvalEF() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p1,p2,p3,p4,p5
-//    }
-//
-//    enum T: Transition {
-//      case t1,t2,t4,t5
-//    }
-//
-//    // Petri net that models the mutual exclusion problem
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p1, to: .t1, labeled: 1),
-//      .pre(from: .p3, to: .t1, labeled: 1),
-//      .post(from: .t1, to: .p4, labeled: 1),
-//      .pre(from: .p2, to: .t2, labeled: 1),
-//      .pre(from: .p3, to: .t2, labeled: 1),
-//      .post(from: .t2, to: .p5, labeled: 1),
-//      .pre(from: .p4, to: .t4, labeled: 1),
-//      .post(from: .t4, to: .p1, labeled: 1),
-//      .post(from: .t4, to: .p3, labeled: 1),
-//      .pre(from: .p5, to: .t5, labeled: 1),
-//      .post(from: .t5, to: .p2, labeled: 1),
-//      .post(from: .t5, to: .p3, labeled: 1)
-//    )
-//    
-//    let ps1: PS<P,T> = .ps([Marking([.p1: 0, .p2: 0, .p3: 0, .p4: 1, .p5: 1])], [])
-//    let ps2: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 1, .p4: 1, .p5: 0])], [])
-//    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 1, .p4: 0, .p5: 1])], [])
-//    let ps4: PS<P,T> = .ps([Marking([.p1: 1, .p2: 1, .p3: 2, .p4: 0, .p5: 0])], [])
-//    let ps5: PS<P,T> = .ps([Marking([.p1: 0, .p2: 1, .p3: 0, .p4: 2, .p5: 0])], [])
-//    let ps6: PS<P,T> = .ps([Marking([.p1: 1, .p2: 0, .p3: 0, .p4: 0, .p5: 2])], [])
-//    let expectedSPS: Set<PS<P,T>> = [ps1, ps2, ps3, ps4, ps5, ps6]
-//    
-//    // Compute all markings that breaks the mutual exclusion
-//    let ctlFormula: CTL<P,T> = .EF(.and(.ap(.t4), .ap(.t5)))
-//    let sps = ctlFormula.eval(petrinet: pn)
-//    
-//    XCTAssertEqual(expectedSPS, PS.simplifiedSPS(sps: sps))
-//  }
-//  
-//  // No answers for EG/AG
-//  func testCTLEval1() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1
-//    }
-//
-//    enum T: Transition {
-//      case t0,t1,t2
-//    }
-//
-//    // Following Petri net:
-//    //          t0
-//    //       -> ▭
-//    // p0  /
-//    // o -
-//    //     \
-//    //       -> ▭ -> o -> ▭
-//    //          t1   p1   t2
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 1),
-//      .pre(from: .p0, to: .t1, labeled: 1),
-//      .post(from: .t1, to: .p1, labeled: 1),
-//      .pre(from: .p1, to: .t2, labeled: 1),
-//      capacity: [.p0: 4, .p1: 4]
-//    )
-//    
-//    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
-//    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
-//    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
-//    let sps1 = ctlFormula1.eval(petrinet: pn)
-//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-//    let sps2 = ctlFormula2.eval(petrinet: pn)
-//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-//    let sps3 = ctlFormula3.eval(petrinet: pn)
-//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-//    
-//    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
-//    let expectedRes: Set<PS<P,T>> = [ps]
-//    
-//    XCTAssertEqual(simpliedSPS1, expectedRes)
-//    XCTAssertEqual(simpliedSPS2, [])
-//    XCTAssertEqual(simpliedSPS3, [])
-//  }
-//  
-//  func testCTLEval2() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1
-//    }
-//
-//    enum T: Transition {
-//      case t0,t1,t2
-//    }
-//
-//    // Following Petri net:
-//    //          t0
-//    //       -> ▭
-//    // p0  /
-//    // o -
-//    //     \
-//    //       -> ▭ -> o <-> ▭
-//    //          t1   p1   t2
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 1),
-//      .pre(from: .p0, to: .t1, labeled: 1),
-//      .post(from: .t1, to: .p1, labeled: 1),
-//      .pre(from: .p1, to: .t2, labeled: 1),
-//      .post(from: .t2, to: .p1, labeled: 1)
-//    )
-//    
-//    let ctlFormula1: CTL<P,T> = .AF(.ap(.t2))
-//    let ctlFormula2: CTL<P,T> = .EG(.ap(.t2))
-//    let ctlFormula3: CTL<P,T> = .AG(.ap(.t2))
-//    let sps1 = ctlFormula1.eval(petrinet: pn)
-//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-//    let sps2 = ctlFormula2.eval(petrinet: pn)
-//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-//    let sps3 = ctlFormula3.eval(petrinet: pn)
-//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-//    
-//    let ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1])], [])
-//    let expectedRes: Set<PS<P,T>> = [ps]
-//    
-//    XCTAssertEqual(simpliedSPS1, expectedRes)
-//    XCTAssertEqual(simpliedSPS2, expectedRes)
-//    XCTAssertEqual(simpliedSPS3, expectedRes)
-//  }
-//  
-//  func testCTLEval3() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1,p2
-//    }
-//
-//    enum T: Transition {
-//      case t0,t1
-//    }
-//
-//    // Following Petri net:
-//    // p1
-//    //       2 t1
-//    //      <--
-//    // p0 o     ▭ --> o p1
-//    //    | -->
-//    //    |  5
-//    //    |
-//    //    |
-//    //     -->  ▭ --> o p2
-//    //      7   t0
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 7),
-//      .post(from: .t0, to: .p2, labeled: 1),
-//      .pre(from: .p0, to: .t1, labeled: 2),
-//      .post(from: .t1, to: .p0, labeled: 5),
-//      .post(from: .t1, to: .p1, labeled: 1)
-//    )
-//    
-//    let ctlFormula1: CTL<P,T> = .AX(.and(.ap(.t1), .not(.ap(.t0))))
-//    let ctlFormula2: CTL<P,T> = .EU(.ap(.t1), .ap(.t0))
-//    let ctlFormula3: CTL<P,T> = .AU(.ap(.t1), .ap(.t0))
-//    let sps1 = ctlFormula1.eval(petrinet: pn)
-//    let simpliedSPS1 = PS.simplifiedSPS(sps: sps1)
-//    let sps2 = ctlFormula2.eval(petrinet: pn)
-//    let simpliedSPS2 = PS.simplifiedSPS(sps: sps2)
-//    let sps3 = ctlFormula3.eval(petrinet: pn)
-//    let simpliedSPS3 = PS.simplifiedSPS(sps: sps3)
-//    
-//    let ps1: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [])
-//    let ps2: PS<P,T> = .ps([Marking([.p0: 2, .p1: 0, .p2: 0])], [Marking([.p0: 4, .p1: 0, .p2: 0])])
-//    let ps3: PS<P,T> = .ps([], [Marking([.p0: 2, .p1: 0, .p2: 0])])
-//    
-//    XCTAssertEqual(simpliedSPS1, [ps2,ps3])
-//    XCTAssertEqual(simpliedSPS2, [ps1])
-//    XCTAssertEqual(simpliedSPS3, [ps1])
-//  }
-//  
-//}
+import XCTest
+@testable import PredicateStructure
+
+final class CTLTests: XCTestCase {
+  
+  func testCTLEvalAX() {
+
+    // Following Petri net:
+    //          t0   p2   t3
+    //       -> ▭ -> o -> ▭
+    // p0  /
+    // o -
+    //     \
+    //       -> ▭ -> o -> ▭
+    //          t1   p1   t2
+    let net = PetriNet(
+      places: ["p0", "p1", "p2"],
+      transitions: ["t0", "t1", "t2", "t3"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 1),
+      .post(from: "t0", to: "p2", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 1),
+      .post(from: "t1", to: "p1", labeled: 1),
+      .pre(from: "p2", to: "t3", labeled: 1),
+      .pre(from: "p1", to: "t2", labeled: 1)
+    )
+    
+    let ps1 = PS(ps: ([Marking(["p0": 1, "p1": 2, "p2": 1], net: net)], []), net: net)
+    let ps2 = PS(ps: ([], [Marking(["p0": 1, "p1": 0, "p2": 0], net: net), Marking(["p0": 0, "p1": 1, "p2": 0], net: net), Marking(["p0": 0, "p1": 0, "p2": 1], net: net)]), net: net)
+    let ps3 = PS(ps: ([Marking(["p0": 0, "p1": 2, "p2": 0], net: net)], [Marking(["p0": 1, "p1": 2, "p2": 0], net: net), Marking(["p0": 0, "p1": 2, "p2": 1], net: net)]), net: net)
+    let ps4 = PS(ps: ([Marking(["p0": 0, "p1": 2, "p2": 1], net: net)], [Marking(["p0": 1, "p1": 2, "p2": 1], net: net)]), net: net)
+    let ps5 = PS(ps: ([Marking(["p0": 1, "p1": 2, "p2": 0], net: net)], [Marking(["p0": 1, "p1": 2, "p2": 1], net: net)]), net: net)
+    
+    let expectedSPS: Set<PS> = [ps1, ps2, ps3, ps4, ps5]
+    
+    let ctlFormula: CTL = .AX(.ap("t2"))
+    let sps = ctlFormula.eval(net: net)
+    let simpliedSPS = ps1.simplified(sps: sps)
+
+    XCTAssertTrue(ps1.isEquiv(sps1: simpliedSPS, sps2: expectedSPS))
+  }
+
+  
+  func testCTLEvalEF() {
+
+    // Petri net that models the mutual exclusion problem
+    let net = PetriNet(
+      places: ["p1", "p2", "p3", "p4", "p5"],
+      transitions: ["t1", "t2", "t4", "t5"],
+      arcs: .pre(from: "p1", to: "t1", labeled: 1),
+      .pre(from: "p3", to: "t1", labeled: 1),
+      .post(from: "t1", to: "p4", labeled: 1),
+      .pre(from: "p2", to: "t2", labeled: 1),
+      .pre(from: "p3", to: "t2", labeled: 1),
+      .post(from: "t2", to: "p5", labeled: 1),
+      .pre(from: "p4", to: "t4", labeled: 1),
+      .post(from: "t4", to: "p1", labeled: 1),
+      .post(from: "t4", to: "p3", labeled: 1),
+      .pre(from: "p5", to: "t5", labeled: 1),
+      .post(from: "t5", to: "p2", labeled: 1),
+      .post(from: "t5", to: "p3", labeled: 1)
+    )
+
+    let ps1 = PS(ps: ([Marking(["p1": 0, "p2": 0, "p3": 0, "p4": 1, "p5": 1], net: net)], []), net: net)
+    let ps2 = PS(ps: ([Marking(["p1": 0, "p2": 1, "p3": 1, "p4": 1, "p5": 0], net: net)], []), net: net)
+    let ps3 = PS(ps: ([Marking(["p1": 1, "p2": 0, "p3": 1, "p4": 0, "p5": 1], net: net)], []), net: net)
+    let ps4 = PS(ps: ([Marking(["p1": 1, "p2": 1, "p3": 2, "p4": 0, "p5": 0], net: net)], []), net: net)
+    let ps5 = PS(ps: ([Marking(["p1": 0, "p2": 1, "p3": 0, "p4": 2, "p5": 0], net: net)], []), net: net)
+    let ps6 = PS(ps: ([Marking(["p1": 1, "p2": 0, "p3": 0, "p4": 0, "p5": 2], net: net)], []), net: net)
+    let expectedSPS: Set<PS> = [ps1, ps2, ps3, ps4, ps5, ps6]
+
+    // Compute all markings that breaks the mutual exclusion
+    let ctlFormula: CTL = .EF(.and(.ap("t4"), .ap("t5")))
+    let sps = ctlFormula.eval(net: net)
+
+    XCTAssertEqual(expectedSPS, ps1.simplified(sps: sps))
+  }
+
+  // No answers for EG/AG
+  func testCTLEval1() {
+    // Following Petri net:
+    //          t0
+    //       -> ▭
+    // p0  /
+    // o -
+    //     \
+    //       -> ▭ -> o -> ▭
+    //          t1   p1   t2
+    let net = PetriNet(
+      places: ["p0", "p1"],
+      transitions: ["t0", "t1", "t2"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 1),
+      .post(from: "t1", to: "p1", labeled: 1),
+      .pre(from: "p1", to: "t2", labeled: 1),
+      capacity: ["p0": 4, "p1": 4]
+    )
+
+    let ctlFormula1: CTL = .AF(.ap("t2"))
+    let ctlFormula2: CTL = .EG(.ap("t2"))
+    let ctlFormula3: CTL = .AG(.ap("t2"))
+    let sps1 = ctlFormula1.eval(net: net)
+    let sps2 = ctlFormula2.eval(net: net)
+    let sps3 = ctlFormula3.eval(net: net)
+
+    let ps = PS(ps: ([Marking(["p0": 0, "p1": 1], net: net)], []), net: net)
+    let expectedRes: Set<PS> = [ps]
+    
+    let simpliedSPS1 = ps.simplified(sps: sps1)
+    let simpliedSPS2 = ps.simplified(sps: sps2)
+    let simpliedSPS3 = ps.simplified(sps: sps3)
+
+    XCTAssertEqual(simpliedSPS1, expectedRes)
+    XCTAssertEqual(simpliedSPS2, [])
+    XCTAssertEqual(simpliedSPS3, [])
+  }
+
+  func testCTLEval2() {
+    // Following Petri net:
+    //          t0
+    //       -> ▭
+    // p0  /
+    // o -
+    //     \
+    //       -> ▭ -> o <-> ▭
+    //          t1   p1   t2
+    let net = PetriNet(
+      places: ["p0", "p1"],
+      transitions: ["t0", "t1", "t2"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 1),
+      .post(from: "t1", to: "p1", labeled: 1),
+      .pre(from: "p1", to: "t2", labeled: 1),
+      .post(from: "t2", to: "p1", labeled: 1)
+    )
+
+    let ctlFormula1: CTL = .AF(.ap("t2"))
+    let ctlFormula2: CTL = .EG(.ap("t2"))
+    let ctlFormula3: CTL = .AG(.ap("t2"))
+    let sps1 = ctlFormula1.eval(net: net)
+    let sps2 = ctlFormula2.eval(net: net)
+    let sps3 = ctlFormula3.eval(net: net)
+
+    let ps: PS = PS(ps: ([Marking(["p0": 0, "p1": 1], net: net)], []), net: net)
+    let expectedRes: Set<PS> = [ps]
+
+    let simpliedSPS1 = ps.simplified(sps: sps1)
+    let simpliedSPS2 = ps.simplified(sps: sps2)
+    let simpliedSPS3 = ps.simplified(sps: sps3)
+    XCTAssertEqual(simpliedSPS1, expectedRes)
+    XCTAssertEqual(simpliedSPS2, expectedRes)
+    XCTAssertEqual(simpliedSPS3, expectedRes)
+  }
+
+  func testCTLEval3() {
+    // Following Petri net:
+    // p1
+    //       2 t1
+    //      <--
+    // p0 o     ▭ --> o p1
+    //    | -->
+    //    |  5
+    //    |
+    //    |
+    //     -->  ▭ --> o p2
+    //      7   t0
+    let net = PetriNet(
+      places: ["p0", "p1", "p2"],
+      transitions: ["t0", "t1"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 7),
+      .post(from: "t0", to: "p2", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 2),
+      .post(from: "t1", to: "p0", labeled: 5),
+      .post(from: "t1", to: "p1", labeled: 1)
+    )
+
+    let ctlFormula1: CTL = .AX(.and(.ap("t1"), .not(.ap("t0"))))
+    let ctlFormula2: CTL = .EU(.ap("t1"), .ap("t0"))
+    let ctlFormula3: CTL = .AU(.ap("t1"), .ap("t0"))
+    let sps1 = ctlFormula1.eval(net: net)
+    let sps2 = ctlFormula2.eval(net: net)
+    let sps3 = ctlFormula3.eval(net: net)
+
+    let ps1 = PS(ps: ([Marking(["p0": 2, "p1": 0, "p2": 0], net: net)], []), net: net)
+    let ps2 = PS(ps: ([Marking(["p0": 2, "p1": 0, "p2": 0], net: net)], [Marking(["p0": 4, "p1": 0, "p2": 0], net: net)]), net: net)
+    let ps3 = PS(ps: ([], [Marking(["p0": 2, "p1": 0, "p2": 0], net: net)]), net: net)
+
+    let simpliedSPS1 = ps1.simplified(sps: sps1)
+    let simpliedSPS2 = ps1.simplified(sps: sps2)
+    let simpliedSPS3 = ps1.simplified(sps: sps3)
+    
+    XCTAssertEqual(simpliedSPS1, [ps2,ps3])
+    XCTAssertEqual(simpliedSPS2, [ps1])
+    XCTAssertEqual(simpliedSPS3, [ps1])
+    
+    print("---------------------")
+    print(simpliedSPS3)
+    print(ps1)
+  }
+  
+}

--- a/Tests/PredicateStructureTests/PetriNetTests.swift
+++ b/Tests/PredicateStructureTests/PetriNetTests.swift
@@ -1,60 +1,60 @@
-import XCTest
-@testable import PredicateStructure
-
-final class PetriNetTests: XCTestCase {
-  
-  func testRevertPN() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1
-    }
-
-    enum T: Transition {
-      case t0, t1
-    }
-
-    let model = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 2),
-      .post(from: .t0, to: .p0, labeled: 1),
-      .post(from: .t0, to: .p1, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 1),
-      .pre(from: .p1, to: .t1, labeled: 1)
-    )
-    let marking = Marking<P>([.p0: 0, .p1: 1])
-
-    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
-    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
-//    print(model.fire(transition: .t1, from: marking1))
-    
-    XCTAssertEqual(model.revert(marking: marking, transition: .t0), revertT0)
-    XCTAssertEqual(model.revert(marking: marking, transition: .t1), revertT1)
-    XCTAssertEqual(model.revert(marking: marking), [revertT0, revertT1])
-    XCTAssertEqual(model.revert(markings: [marking]), [revertT0, revertT1])
-    
-  }
-  
-  func testCapacity() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1
-    }
-
-    enum T: Transition {
-      case t0
-    }
-
-    let model = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 1),
-      .post(from: .t0, to: .p1, labeled: 2),
-      capacity: [.p0: 2, .p1: 2]
-    )
-    let marking1 = Marking<P>([.p0: 1, .p1: 0])
-    let marking2 = Marking<P>([.p0: 1, .p1: 1])
-
-    XCTAssertEqual(model.fire(transition: .t0, from: marking1), Marking<P>([.p0: 0, .p1: 2]))
-    XCTAssertNil(model.fire(transition: .t0, from: marking2))
-  }
-  
-}
+//import XCTest
+//@testable import PredicateStructure
+//
+//final class PetriNetTests: XCTestCase {
+//  
+//  func testRevertPN() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1
+//    }
+//
+//    enum T: Transition {
+//      case t0, t1
+//    }
+//
+//    let model = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 2),
+//      .post(from: .t0, to: .p0, labeled: 1),
+//      .post(from: .t0, to: .p1, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 1),
+//      .pre(from: .p1, to: .t1, labeled: 1)
+//    )
+//    let marking = Marking<P>([.p0: 0, .p1: 1])
+//
+//    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
+//    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
+////    print(model.fire(transition: .t1, from: marking1))
+//    
+//    XCTAssertEqual(model.revert(marking: marking, transition: .t0), revertT0)
+//    XCTAssertEqual(model.revert(marking: marking, transition: .t1), revertT1)
+//    XCTAssertEqual(model.revert(marking: marking), [revertT0, revertT1])
+//    XCTAssertEqual(model.revert(markings: [marking]), [revertT0, revertT1])
+//    
+//  }
+//  
+//  func testCapacity() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1
+//    }
+//
+//    enum T: Transition {
+//      case t0
+//    }
+//
+//    let model = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 1),
+//      .post(from: .t0, to: .p1, labeled: 2),
+//      capacity: [.p0: 2, .p1: 2]
+//    )
+//    let marking1 = Marking<P>([.p0: 1, .p1: 0])
+//    let marking2 = Marking<P>([.p0: 1, .p1: 1])
+//
+//    XCTAssertEqual(model.fire(transition: .t0, from: marking1), Marking<P>([.p0: 0, .p1: 2]))
+//    XCTAssertNil(model.fire(transition: .t0, from: marking2))
+//  }
+//  
+//}

--- a/Tests/PredicateStructureTests/PetriNetTests.swift
+++ b/Tests/PredicateStructureTests/PetriNetTests.swift
@@ -1,19 +1,20 @@
-//import XCTest
-//@testable import PredicateStructure
-//
-//final class PetriNetTests: XCTestCase {
-//  
-//  func testRevertPN() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1
-//    }
-//
-//    enum T: Transition {
-//      case t0, t1
-//    }
-//
+import XCTest
+@testable import PredicateStructure
+
+final class PetriNetTests: XCTestCase {
+  
+  func testRevertPN() {
+
+    let pn = PetriNet(
+      places: ["p0", "p1"],
+      transitions: ["t0", "t1"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 2),
+      .post(from: "t0", to: "p0", labeled: 1),
+      .post(from: "t0", to: "p1", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 1),
+      .pre(from: "p1", to: "t1", labeled: 1)
+    )
+    
 //    let model = PetriNet<P, T>(
 //      .pre(from: .p0, to: .t0, labeled: 2),
 //      .post(from: .t0, to: .p0, labeled: 1),
@@ -21,40 +22,38 @@
 //      .pre(from: .p0, to: .t1, labeled: 1),
 //      .pre(from: .p1, to: .t1, labeled: 1)
 //    )
-//    let marking = Marking<P>([.p0: 0, .p1: 1])
+    
+    let marking = Marking(storage: ["p0": 0, "p1": 1], petrinet: pn)
+    
+//    print(model)
+//    print(marking)
+
+    let revertT0 = Marking(storage: ["p0": 2, "p1": 0], petrinet: pn)
+    let revertT1 = Marking(storage: ["p0": 1, "p1": 2], petrinet: pn)
+////    print(model.fire(transition: "t1", from: marking))
 //
-//    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
-//    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
-////    print(model.fire(transition: .t1, from: marking1))
-//    
-//    XCTAssertEqual(model.revert(marking: marking, transition: .t0), revertT0)
-//    XCTAssertEqual(model.revert(marking: marking, transition: .t1), revertT1)
-//    XCTAssertEqual(model.revert(marking: marking), [revertT0, revertT1])
-//    XCTAssertEqual(model.revert(markings: [marking]), [revertT0, revertT1])
-//    
-//  }
-//  
-//  func testCapacity() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1
-//    }
-//
-//    enum T: Transition {
-//      case t0
-//    }
-//
-//    let model = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 1),
-//      .post(from: .t0, to: .p1, labeled: 2),
-//      capacity: [.p0: 2, .p1: 2]
-//    )
-//    let marking1 = Marking<P>([.p0: 1, .p1: 0])
-//    let marking2 = Marking<P>([.p0: 1, .p1: 1])
-//
-//    XCTAssertEqual(model.fire(transition: .t0, from: marking1), Marking<P>([.p0: 0, .p1: 2]))
-//    XCTAssertNil(model.fire(transition: .t0, from: marking2))
-//  }
-//  
-//}
+    XCTAssertEqual(pn.revert(marking: marking, transition: "t0"), revertT0)
+    XCTAssertEqual(pn.revert(marking: marking, transition: "t1"), revertT1)
+    XCTAssertEqual(pn.revert(marking: marking), [revertT0, revertT1])
+    XCTAssertEqual(pn.revert(markings: [marking]), [revertT0, revertT1])
+    
+  }
+  
+  func testCapacity() {
+
+    let pn = PetriNet(
+      places: ["p0", "p1"],
+      transitions: ["t0"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 1),
+      .post(from: "t0", to: "p1", labeled: 2),
+      capacity: ["p0": 2, "p1": 2]
+    )
+      
+    let marking1 = Marking(storage: ["p0": 1, "p1": 0], petrinet: pn)
+    let marking2 = Marking(storage: ["p0": 1, "p1": 1], petrinet: pn)
+
+    XCTAssertEqual(pn.fire(transition: "t0", from: marking1), Marking(storage: ["p0": 0, "p1": 2], petrinet: pn))
+    XCTAssertNil(pn.fire(transition: "t0", from: marking2))
+  }
+  
+}

--- a/Tests/PredicateStructureTests/PetriNetTests.swift
+++ b/Tests/PredicateStructureTests/PetriNetTests.swift
@@ -23,13 +23,13 @@ final class PetriNetTests: XCTestCase {
 //      .pre(from: .p1, to: .t1, labeled: 1)
 //    )
     
-    let marking = Marking(storage: ["p0": 0, "p1": 1], petrinet: pn)
+    let marking = Marking(["p0": 0, "p1": 1], net: pn)
     
 //    print(model)
 //    print(marking)
 
-    let revertT0 = Marking(storage: ["p0": 2, "p1": 0], petrinet: pn)
-    let revertT1 = Marking(storage: ["p0": 1, "p1": 2], petrinet: pn)
+    let revertT0 = Marking(["p0": 2, "p1": 0], net: pn)
+    let revertT1 = Marking(["p0": 1, "p1": 2], net: pn)
 ////    print(model.fire(transition: "t1", from: marking))
 //
     XCTAssertEqual(pn.revert(marking: marking, transition: "t0"), revertT0)
@@ -49,10 +49,10 @@ final class PetriNetTests: XCTestCase {
       capacity: ["p0": 2, "p1": 2]
     )
       
-    let marking1 = Marking(storage: ["p0": 1, "p1": 0], petrinet: pn)
-    let marking2 = Marking(storage: ["p0": 1, "p1": 1], petrinet: pn)
+    let marking1 = Marking(["p0": 1, "p1": 0], net: pn)
+    let marking2 = Marking(["p0": 1, "p1": 1], net: pn)
 
-    XCTAssertEqual(pn.fire(transition: "t0", from: marking1), Marking(storage: ["p0": 0, "p1": 2], petrinet: pn))
+    XCTAssertEqual(pn.fire(transition: "t0", from: marking1), Marking(["p0": 0, "p1": 2], net: pn))
     XCTAssertNil(pn.fire(transition: "t0", from: marking2))
   }
   

--- a/Tests/PredicateStructureTests/PredicateStructureTests.swift
+++ b/Tests/PredicateStructureTests/PredicateStructureTests.swift
@@ -1,262 +1,262 @@
-import XCTest
-@testable import PredicateStructure
-
-final class PredicateStructureTests: XCTestCase {
-  
-//  func testReminderPN() {
+//import XCTest
+//@testable import PredicateStructure
+//
+//final class PredicateStructureTests: XCTestCase {
+//  
+////  func testReminderPN() {
+////    enum P: Place {
+////      typealias Content = Int
+////
+////      case p1,p2,p3
+////    }
+////
+////    enum T: Transition {
+////      case t1//, t2
+////    }
+////
+////    let model = HeroNet<P, T>(
+////      .pre(from: .p1, to: .t1, labeled: 1),
+////      .pre(from: .p2, to: .t1, labeled: 2),
+////      .post(from: .t1, to: .p3, labeled: 3)
+////    )
+////    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
+////
+////    print(model.fire(transition: .t1, from: marking1))
+////  }
+//  
+//  func testPS() {
+//    
+//    typealias SPS = Set<PS<P,T>>
 //    enum P: Place {
 //      typealias Content = Int
-//
+//      
 //      case p1,p2,p3
 //    }
-//
+//    
 //    enum T: Transition {
 //      case t1//, t2
 //    }
-//
-//    let model = HeroNet<P, T>(
-//      .pre(from: .p1, to: .t1, labeled: 1),
-//      .pre(from: .p2, to: .t1, labeled: 2),
-//      .post(from: .t1, to: .p3, labeled: 3)
-//    )
+//    
 //    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
+//    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
+//    let expectedConvMax = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
+//    let expectedConvMin = Marking<P>([.p1: 1, .p2: 5, .p3: 2])
 //
-//    print(model.fire(transition: .t1, from: marking1))
+//    XCTAssertEqual(PS<P,T>.convMax(markings: [marking1, marking2]), [expectedConvMax])
+//    XCTAssertEqual(PS<P,T>.convMin(markings: [marking1, marking2]), [expectedConvMin])
+//    
+//    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
+//    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
+//    
+//    XCTAssertEqual(PS<P,T>.minSet(markings: [marking1, marking2, marking3, marking4]), [marking4])
+//
+//    let marking5 = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
+//    let ps: PS<P,T> = .ps([marking1, marking3], [marking2])
+//    let psCan = PS<P,T>.ps([marking1], [marking5])
+//          
+//    XCTAssertEqual(ps.canPS(), psCan)
+//    
+//    let marking6: Marking<P> = [.p1: 1, .p2: 3, .p3: 5]
+//    
+//    let expectedPS1: PS<P,T> = .ps([marking6], [Marking([.p1: 2, .p2: 3, .p3: 5]), Marking([.p1: 1, .p2: 4, .p3: 5]), Marking([.p1: 1, .p2: 3, .p3: 6])])
+//    XCTAssertEqual(PS.encodeMarking(marking6), expectedPS1)
+//    
+//    let marking7: Marking<P> = [.p1: 1, .p2: 3, .p3: 6]
+//    let expectedPS2: PS<P,T> = .ps([marking7], [Marking([.p1: 2, .p2: 3, .p3: 6]), Marking([.p1: 1, .p2: 4, .p3: 6]), Marking([.p1: 1, .p2: 3, .p3: 7])])
+//    
+//    XCTAssertEqual(PS<P,T>.encodeMarkingSet([marking6, marking7]), [expectedPS1,expectedPS2])
 //  }
-  
-  func testPS() {
-    
-    typealias SPS = Set<PS<P,T>>
-    enum P: Place {
-      typealias Content = Int
-      
-      case p1,p2,p3
-    }
-    
-    enum T: Transition {
-      case t1//, t2
-    }
-    
-    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
-    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
-    let expectedConvMax = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
-    let expectedConvMin = Marking<P>([.p1: 1, .p2: 5, .p3: 2])
-
-    XCTAssertEqual(PS<P,T>.convMax(markings: [marking1, marking2]), [expectedConvMax])
-    XCTAssertEqual(PS<P,T>.convMin(markings: [marking1, marking2]), [expectedConvMin])
-    
-    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
-    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
-    
-    XCTAssertEqual(PS<P,T>.minSet(markings: [marking1, marking2, marking3, marking4]), [marking4])
-
-    let marking5 = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
-    let ps: PS<P,T> = .ps([marking1, marking3], [marking2])
-    let psCan = PS<P,T>.ps([marking1], [marking5])
-          
-    XCTAssertEqual(ps.canPS(), psCan)
-    
-    let marking6: Marking<P> = [.p1: 1, .p2: 3, .p3: 5]
-    
-    let expectedPS1: PS<P,T> = .ps([marking6], [Marking([.p1: 2, .p2: 3, .p3: 5]), Marking([.p1: 1, .p2: 4, .p3: 5]), Marking([.p1: 1, .p2: 3, .p3: 6])])
-    XCTAssertEqual(PS.encodeMarking(marking6), expectedPS1)
-    
-    let marking7: Marking<P> = [.p1: 1, .p2: 3, .p3: 6]
-    let expectedPS2: PS<P,T> = .ps([marking7], [Marking([.p1: 2, .p2: 3, .p3: 6]), Marking([.p1: 1, .p2: 4, .p3: 6]), Marking([.p1: 1, .p2: 3, .p3: 7])])
-    
-    XCTAssertEqual(PS<P,T>.encodeMarkingSet([marking6, marking7]), [expectedPS1,expectedPS2])
-  }
-  
-  func testSPS1() {
-    typealias SPS = Set<PS<P,T>>
-    enum P: Place {
-      typealias Content = Int
-      
-      case p1,p2,p3
-    }
-    
-    enum T: Transition {
-      case t1//, t2
-    }
-    
-    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
-    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
-    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
-    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
-    
-    let ps1 = PS<P,T>.ps([marking1], [marking2])
-    let ps2 = PS<P,T>.ps([marking3], [marking4])
-    
-    XCTAssertEqual(PS<P,T>.union(sps1: [ps1], sps2: [.empty]), [ps1])
-    XCTAssertEqual(PS<P,T>.intersection(sps1: [ps1], sps2: [ps2] , isCanonical: false), [PS.ps([marking1, marking3], [marking2, marking4])])
-    
-    let ps3 = PS<P,T>.ps([marking2], [marking3])
-    
-    let expectedSPS: SPS = [
-      .ps([marking1, marking2], [marking2, marking3]),
-      .ps([marking3, marking2], [marking3, marking4]),
-    ]
-    
-    XCTAssertEqual(PS.intersection(sps1: [ps1,ps2], sps2: [ps3], isCanonical: false), expectedSPS)
-  }
-  
-  func testSPS2() {
-    typealias SPS = Set<PS<P,T>>
-    enum P: Place {
-      typealias Content = Int
-      
-      case p1,p2
-    }
-    
-    enum T: Transition {
-      case t1//, t2
-    }
-    
-    let marking1 = Marking<P>([.p1: 1, .p2: 2])
-    let marking2 = Marking<P>([.p1: 3, .p2: 2])
-    let marking3 = Marking<P>([.p1: 3, .p2: 0])
-    let marking4 = Marking<P>([.p1: 5, .p2: 8])
-    let sps: SPS = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
-    let expectedSPS: SPS = [.ps([], [marking1, marking3]), .ps([marking4], [])]
-    
-    XCTAssertEqual(PS.notSPS(sps: sps), expectedSPS)
-  }
-  
-  func testSPSObservator() {
-    typealias SPS = Set<PS<P,T>>
-    enum P: Place {
-      typealias Content = Int
-      
-      case p1,p2
-    }
-    
-    enum T: Transition {
-      case t1//, t2
-    }
-    
-    var marking1 = Marking<P>([.p1: 4, .p2: 5])
-    var marking2 = Marking<P>([.p1: 9, .p2: 10])
-    var marking3 = Marking<P>([.p1: 3, .p2: 5])
-    var marking4 = Marking<P>([.p1: 11, .p2: 10])
-    var sps1: SPS = [.ps([marking1], [marking2])]
-    var sps2: SPS = [.ps([marking3], [marking4])]
-    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,10)})}
-    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
-
-    marking4 = Marking<P>([.p1: 11, .p2: 9])
-    sps2 = [.ps([marking3], [marking4])]
-    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,9)})}
-    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: sps2))
-    
-    marking4 = Marking<P>([.p1: 7, .p2: 7])
-    let marking5 = Marking<P>([.p1: 6, .p2: 4])
-    let marking6 = Marking<P>([.p1: 14, .p2: 11])
-    sps2 = [.ps([marking3], [marking4]), .ps([marking5], [marking6])]
-    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
-    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
-    // ({(4,5)}, {(9,10)}) ∈ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
-    XCTAssertTrue(PS.isIn(ps: .ps([marking1], [marking2]), sps: sps2))
-    
-    // ∅ ⊆ {({(4,5)}, {(9,10)})}
-    XCTAssertTrue(PS.isIncluded(sps1: [], sps2: sps1))
-    // {({(4,5)}, {(9,10)})} ⊆ ∅
-    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: []))
-    
-    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps1))
-    
-    marking1 = Marking<P>([.p1: 1, .p2: 2])
-    marking2 = Marking<P>([.p1: 5, .p2: 8])
-    marking3 = Marking<P>([.p1: 3, .p2: 0])
-    marking4 = Marking<P>([.p1: 3, .p2: 2])
-    
-    sps1 = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
-    sps2 = [.ps([marking1], [marking4]), .ps([marking3], [marking2])]
-
-    // {({(1,2)}, {(5,8)}), ({(3,0)}, {(3,2)})} ≈ {({(1,2)}, {(3,2)}), ({(3,0)}, {(5,8)})}
-    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps2))
-    
-    let ps1: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 5, .p2: 5])])
-    let ps2: PS<P,T> = .ps([Marking([.p1: 5, .p2: 5])], [Marking([.p1: 10, .p2: 7])])
-    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 10, .p2: 7])])
-
-    XCTAssertTrue(PS.equiv(sps1: [ps1,ps2], sps2: [ps3]))
-    
-    let ps4: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 8, .p2: 9])])
-    let ps5: PS<P,T> = .ps([Marking([.p1: 7, .p2: 8])], [Marking([.p1: 10, .p2: 10])])
-    let ps6: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 10, .p2: 10])])
-    XCTAssertTrue(PS.equiv(sps1: [ps4,ps5], sps2: [ps6]))
-    
-    let ps7: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [Marking([.p1: 4, .p2: 4])])
-    let ps8: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [])
-    let ps9: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [])
-    let ps10: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 4, .p2: 4])])
-    
-    XCTAssertTrue(PS.equiv(sps1: [ps7,ps8], sps2: [ps9,ps10]))
-  }
-  
-  func testRevertPS() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1
-    }
-
-    enum T: Transition {
-      case t0, t1
-    }
-
-    let model = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 2),
-      .post(from: .t0, to: .p0, labeled: 1),
-      .post(from: .t0, to: .p1, labeled: 1),
-      .pre(from: .p0, to: .t1, labeled: 1),
-      .pre(from: .p1, to: .t1, labeled: 1)
-    )
-    let marking1 = Marking<P>([.p0: 0, .p1: 1])
-    let marking2 = Marking<P>([.p0: 1, .p1: 1])
-
-    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
-    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
-    let revertT2 = Marking<P>([.p0: 2, .p1: 2])
-//    print(model.fire(transition: .t1, from: marking1))
-    
-    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t0, petrinet: model), PS.ps([revertT0], []))
-    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t1, petrinet: model), PS.ps([revertT1], []))
-    XCTAssertEqual(PS.revert(ps: .ps([marking1,marking2], []), transition: .t1, petrinet: model), PS.ps([revertT1, revertT2], []))
-    print(model.revert(marking: marking2))    
-  }
-
-  func testUnderlyingMarking() {
-    enum P: Place {
-      typealias Content = Int
-
-      case p0,p1,p2
-    }
-
-    enum T: Transition {
-      case t0
-    }
-    
-    let pn = PetriNet<P, T>(
-      .pre(from: .p0, to: .t0, labeled: 1),
-      .post(from: .t0, to: .p1, labeled: 1),
-      capacity: [.p0: 3, .p1: 3, .p2: 3]
-    )
-    
-    var ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1, .p2: 0])], [Marking([.p0: 1, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 1])])
-    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 1)
-    
-    // 4*4*4
-    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 0])], [])
-    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 64)
-    
-    // 4*4*3
-    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 1])], [])
-    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 48)
-
-    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 2])], [Marking([.p0: 0, .p1: 0, .p2: 1])])
-    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 0)
-  }
-
-  
-}
+//  
+//  func testSPS1() {
+//    typealias SPS = Set<PS<P,T>>
+//    enum P: Place {
+//      typealias Content = Int
+//      
+//      case p1,p2,p3
+//    }
+//    
+//    enum T: Transition {
+//      case t1//, t2
+//    }
+//    
+//    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
+//    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
+//    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
+//    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
+//    
+//    let ps1 = PS<P,T>.ps([marking1], [marking2])
+//    let ps2 = PS<P,T>.ps([marking3], [marking4])
+//    
+//    XCTAssertEqual(PS<P,T>.union(sps1: [ps1], sps2: [.empty]), [ps1])
+//    XCTAssertEqual(PS<P,T>.intersection(sps1: [ps1], sps2: [ps2] , isCanonical: false), [PS.ps([marking1, marking3], [marking2, marking4])])
+//    
+//    let ps3 = PS<P,T>.ps([marking2], [marking3])
+//    
+//    let expectedSPS: SPS = [
+//      .ps([marking1, marking2], [marking2, marking3]),
+//      .ps([marking3, marking2], [marking3, marking4]),
+//    ]
+//    
+//    XCTAssertEqual(PS.intersection(sps1: [ps1,ps2], sps2: [ps3], isCanonical: false), expectedSPS)
+//  }
+//  
+//  func testSPS2() {
+//    typealias SPS = Set<PS<P,T>>
+//    enum P: Place {
+//      typealias Content = Int
+//      
+//      case p1,p2
+//    }
+//    
+//    enum T: Transition {
+//      case t1//, t2
+//    }
+//    
+//    let marking1 = Marking<P>([.p1: 1, .p2: 2])
+//    let marking2 = Marking<P>([.p1: 3, .p2: 2])
+//    let marking3 = Marking<P>([.p1: 3, .p2: 0])
+//    let marking4 = Marking<P>([.p1: 5, .p2: 8])
+//    let sps: SPS = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
+//    let expectedSPS: SPS = [.ps([], [marking1, marking3]), .ps([marking4], [])]
+//    
+//    XCTAssertEqual(PS.notSPS(sps: sps), expectedSPS)
+//  }
+//  
+//  func testSPSObservator() {
+//    typealias SPS = Set<PS<P,T>>
+//    enum P: Place {
+//      typealias Content = Int
+//      
+//      case p1,p2
+//    }
+//    
+//    enum T: Transition {
+//      case t1//, t2
+//    }
+//    
+//    var marking1 = Marking<P>([.p1: 4, .p2: 5])
+//    var marking2 = Marking<P>([.p1: 9, .p2: 10])
+//    var marking3 = Marking<P>([.p1: 3, .p2: 5])
+//    var marking4 = Marking<P>([.p1: 11, .p2: 10])
+//    var sps1: SPS = [.ps([marking1], [marking2])]
+//    var sps2: SPS = [.ps([marking3], [marking4])]
+//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,10)})}
+//    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
+//
+//    marking4 = Marking<P>([.p1: 11, .p2: 9])
+//    sps2 = [.ps([marking3], [marking4])]
+//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,9)})}
+//    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: sps2))
+//    
+//    marking4 = Marking<P>([.p1: 7, .p2: 7])
+//    let marking5 = Marking<P>([.p1: 6, .p2: 4])
+//    let marking6 = Marking<P>([.p1: 14, .p2: 11])
+//    sps2 = [.ps([marking3], [marking4]), .ps([marking5], [marking6])]
+//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
+//    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
+//    // ({(4,5)}, {(9,10)}) ∈ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
+//    XCTAssertTrue(PS.isIn(ps: .ps([marking1], [marking2]), sps: sps2))
+//    
+//    // ∅ ⊆ {({(4,5)}, {(9,10)})}
+//    XCTAssertTrue(PS.isIncluded(sps1: [], sps2: sps1))
+//    // {({(4,5)}, {(9,10)})} ⊆ ∅
+//    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: []))
+//    
+//    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps1))
+//    
+//    marking1 = Marking<P>([.p1: 1, .p2: 2])
+//    marking2 = Marking<P>([.p1: 5, .p2: 8])
+//    marking3 = Marking<P>([.p1: 3, .p2: 0])
+//    marking4 = Marking<P>([.p1: 3, .p2: 2])
+//    
+//    sps1 = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
+//    sps2 = [.ps([marking1], [marking4]), .ps([marking3], [marking2])]
+//
+//    // {({(1,2)}, {(5,8)}), ({(3,0)}, {(3,2)})} ≈ {({(1,2)}, {(3,2)}), ({(3,0)}, {(5,8)})}
+//    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps2))
+//    
+//    let ps1: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 5, .p2: 5])])
+//    let ps2: PS<P,T> = .ps([Marking([.p1: 5, .p2: 5])], [Marking([.p1: 10, .p2: 7])])
+//    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 10, .p2: 7])])
+//
+//    XCTAssertTrue(PS.equiv(sps1: [ps1,ps2], sps2: [ps3]))
+//    
+//    let ps4: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 8, .p2: 9])])
+//    let ps5: PS<P,T> = .ps([Marking([.p1: 7, .p2: 8])], [Marking([.p1: 10, .p2: 10])])
+//    let ps6: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 10, .p2: 10])])
+//    XCTAssertTrue(PS.equiv(sps1: [ps4,ps5], sps2: [ps6]))
+//    
+//    let ps7: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [Marking([.p1: 4, .p2: 4])])
+//    let ps8: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [])
+//    let ps9: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [])
+//    let ps10: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 4, .p2: 4])])
+//    
+//    XCTAssertTrue(PS.equiv(sps1: [ps7,ps8], sps2: [ps9,ps10]))
+//  }
+//  
+//  func testRevertPS() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1
+//    }
+//
+//    enum T: Transition {
+//      case t0, t1
+//    }
+//
+//    let model = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 2),
+//      .post(from: .t0, to: .p0, labeled: 1),
+//      .post(from: .t0, to: .p1, labeled: 1),
+//      .pre(from: .p0, to: .t1, labeled: 1),
+//      .pre(from: .p1, to: .t1, labeled: 1)
+//    )
+//    let marking1 = Marking<P>([.p0: 0, .p1: 1])
+//    let marking2 = Marking<P>([.p0: 1, .p1: 1])
+//
+//    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
+//    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
+//    let revertT2 = Marking<P>([.p0: 2, .p1: 2])
+////    print(model.fire(transition: .t1, from: marking1))
+//    
+//    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t0, petrinet: model), PS.ps([revertT0], []))
+//    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t1, petrinet: model), PS.ps([revertT1], []))
+//    XCTAssertEqual(PS.revert(ps: .ps([marking1,marking2], []), transition: .t1, petrinet: model), PS.ps([revertT1, revertT2], []))
+//    print(model.revert(marking: marking2))    
+//  }
+//
+//  func testUnderlyingMarking() {
+//    enum P: Place {
+//      typealias Content = Int
+//
+//      case p0,p1,p2
+//    }
+//
+//    enum T: Transition {
+//      case t0
+//    }
+//    
+//    let pn = PetriNet<P, T>(
+//      .pre(from: .p0, to: .t0, labeled: 1),
+//      .post(from: .t0, to: .p1, labeled: 1),
+//      capacity: [.p0: 3, .p1: 3, .p2: 3]
+//    )
+//    
+//    var ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1, .p2: 0])], [Marking([.p0: 1, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 1])])
+//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 1)
+//    
+//    // 4*4*4
+//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 0])], [])
+//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 64)
+//    
+//    // 4*4*3
+//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 1])], [])
+//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 48)
+//
+//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 2])], [Marking([.p0: 0, .p1: 0, .p2: 1])])
+//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 0)
+//  }
+//
+//  
+//}

--- a/Tests/PredicateStructureTests/PredicateStructureTests.swift
+++ b/Tests/PredicateStructureTests/PredicateStructureTests.swift
@@ -218,38 +218,30 @@ final class PredicateStructureTests: XCTestCase {
     XCTAssertEqual(ps4.revert(transition: "t1"), ps5)
     print(net.revert(marking: marking2))
   }
-//
-//  func testUnderlyingMarking() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1,p2
-//    }
-//
-//    enum T: Transition {
-//      case t0
-//    }
-//
-//    let pn = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 1),
-//      .post(from: .t0, to: .p1, labeled: 1),
-//      capacity: [.p0: 3, .p1: 3, .p2: 3]
-//    )
-//
-//    var ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1, .p2: 0])], [Marking([.p0: 1, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 1])])
-//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 1)
-//
-//    // 4*4*4
-//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 0])], [])
-//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 64)
-//
-//    // 4*4*3
-//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 1])], [])
-//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 48)
-//
-//    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 2])], [Marking([.p0: 0, .p1: 0, .p2: 1])])
-//    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 0)
-//  }
 
+  func testUnderlyingMarking() {
+
+    let net = PetriNet(
+      places: ["p0", "p1", "p2"],
+      transitions: ["t0"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 1),
+      .post(from: "t0", to: "p1", labeled: 1),
+      capacity: ["p0": 3, "p1": 3, "p2": 3]
+    )
+
+    var ps: PS = PS(ps: ([Marking(["p0": 0, "p1": 1, "p2": 0], net: net)], [Marking(["p0": 1, "p1": 1, "p2": 0], net: net), Marking(["p0": 0, "p1": 2, "p2": 0], net: net), Marking(["p0": 0, "p1": 1, "p2": 1], net: net)]), net: net)
+    XCTAssertEqual(ps.underlyingMarkings().count, 1)
+
+    // 4*4*4
+    ps = PS(ps: ([Marking(["p0": 0, "p1": 0, "p2": 0], net: net)], []), net: net)
+    XCTAssertEqual(ps.underlyingMarkings().count, 64)
+
+    // 4*4*3
+    ps = PS(ps: ([Marking(["p0": 0, "p1": 0, "p2": 1], net: net)], []), net: net)
+    XCTAssertEqual(ps.underlyingMarkings().count, 48)
+
+    ps = PS(ps: ([Marking(["p0": 0, "p1": 0, "p2": 2], net: net)], [Marking(["p0": 0, "p1": 0, "p2": 1], net: net)]), net: net)
+    XCTAssertEqual(ps.underlyingMarkings().count, 0)
+  }
   
 }

--- a/Tests/PredicateStructureTests/PredicateStructureTests.swift
+++ b/Tests/PredicateStructureTests/PredicateStructureTests.swift
@@ -1,139 +1,137 @@
-//import XCTest
-//@testable import PredicateStructure
-//
-//final class PredicateStructureTests: XCTestCase {
-//  
-////  func testReminderPN() {
-////    enum P: Place {
-////      typealias Content = Int
-////
-////      case p1,p2,p3
-////    }
-////
-////    enum T: Transition {
-////      case t1//, t2
-////    }
-////
-////    let model = HeroNet<P, T>(
-////      .pre(from: .p1, to: .t1, labeled: 1),
-////      .pre(from: .p2, to: .t1, labeled: 2),
-////      .post(from: .t1, to: .p3, labeled: 3)
-////    )
-////    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
-////
-////    print(model.fire(transition: .t1, from: marking1))
-////  }
-//  
-//  func testPS() {
-//    
-//    typealias SPS = Set<PS<P,T>>
+import XCTest
+@testable import PredicateStructure
+
+final class PredicateStructureTests: XCTestCase {
+  
+//  func testReminderPN() {
 //    enum P: Place {
 //      typealias Content = Int
-//      
+//
 //      case p1,p2,p3
 //    }
-//    
+//
 //    enum T: Transition {
 //      case t1//, t2
 //    }
-//    
+//
+//    let model = HeroNet<P, T>(
+//      .pre(from: .p1, to: .t1, labeled: 1),
+//      .pre(from: .p2, to: .t1, labeled: 2),
+//      .post(from: .t1, to: .p3, labeled: 3)
+//    )
 //    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
-//    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
-//    let expectedConvMax = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
-//    let expectedConvMin = Marking<P>([.p1: 1, .p2: 5, .p3: 2])
 //
-//    XCTAssertEqual(PS<P,T>.convMax(markings: [marking1, marking2]), [expectedConvMax])
-//    XCTAssertEqual(PS<P,T>.convMin(markings: [marking1, marking2]), [expectedConvMin])
-//    
-//    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
-//    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
-//    
-//    XCTAssertEqual(PS<P,T>.minSet(markings: [marking1, marking2, marking3, marking4]), [marking4])
-//
-//    let marking5 = Marking<P>([.p1: 4, .p2: 42, .p3: 6])
-//    let ps: PS<P,T> = .ps([marking1, marking3], [marking2])
-//    let psCan = PS<P,T>.ps([marking1], [marking5])
-//          
-//    XCTAssertEqual(ps.canPS(), psCan)
-//    
-//    let marking6: Marking<P> = [.p1: 1, .p2: 3, .p3: 5]
-//    
-//    let expectedPS1: PS<P,T> = .ps([marking6], [Marking([.p1: 2, .p2: 3, .p3: 5]), Marking([.p1: 1, .p2: 4, .p3: 5]), Marking([.p1: 1, .p2: 3, .p3: 6])])
-//    XCTAssertEqual(PS.encodeMarking(marking6), expectedPS1)
-//    
-//    let marking7: Marking<P> = [.p1: 1, .p2: 3, .p3: 6]
-//    let expectedPS2: PS<P,T> = .ps([marking7], [Marking([.p1: 2, .p2: 3, .p3: 6]), Marking([.p1: 1, .p2: 4, .p3: 6]), Marking([.p1: 1, .p2: 3, .p3: 7])])
-//    
-//    XCTAssertEqual(PS<P,T>.encodeMarkingSet([marking6, marking7]), [expectedPS1,expectedPS2])
+//    print(model.fire(transition: .t1, from: marking1))
 //  }
-//  
+  
+  func testPS() {
+    
+    typealias SPS = Set<PS>
+    
+    let net = PetriNet(
+      places: ["p1", "p2", "p3"],
+      transitions: ["t1"],
+      arcs: .pre(from: "p1", to: "t1", labeled: 2)
+    )
+    
+    let marking1 = Marking(["p1": 4, "p2": 5, "p3": 6], net: net)
+    let marking2 = Marking(["p1": 1, "p2": 42, "p3": 2], net: net)
+    let expectedConvMax = Marking(["p1": 4, "p2": 42, "p3": 6], net: net)
+    let expectedConvMin = Marking(["p1": 1, "p2": 5, "p3": 2], net: net)
+    let psEmpty: PS = PS(ps: nil, net: net)
+
+    XCTAssertEqual(psEmpty.convMax(markings: [marking1, marking2]), [expectedConvMax])
+    XCTAssertEqual(psEmpty.convMin(markings: [marking1, marking2]), [expectedConvMin])
+    
+    let marking3 = Marking(["p1": 3, "p2": 5, "p3": 6], net: net)
+    let marking4 = Marking(["p1": 0, "p2": 4, "p3": 0], net: net)
+    
+    XCTAssertEqual(psEmpty.minSet(markings: [marking1, marking2, marking3, marking4]), [marking4])
+
+    let marking5 = Marking(["p1": 4, "p2": 42, "p3": 6], net: net)
+    let ps = PS(ps: ([marking1, marking3], [marking2]), net: net)
+    let psCan = PS(ps: ([marking1], [marking5]), net: net)
+          
+    XCTAssertEqual(ps.canonised(), psCan)
+    
+    let marking6 = Marking(["p1": 1, "p2": 3, "p3": 5], net: net)
+    
+    let expectedPS1 = PS(ps: ([marking6], [Marking(["p1": 2, "p2": 3, "p3": 5], net: net), Marking(["p1": 1, "p2": 4, "p3": 5], net: net), Marking(["p1": 1, "p2": 3, "p3": 6], net: net)]), net: net)
+    XCTAssertEqual(psEmpty.encodeMarking(marking6), expectedPS1)
+    
+    let marking7 = Marking(["p1": 1, "p2": 3, "p3": 6], net: net)
+    let expectedPS2 = PS(ps: ([marking7], [Marking(["p1": 2, "p2": 3, "p3": 6], net: net), Marking(["p1": 1, "p2": 4, "p3": 6], net: net), Marking(["p1": 1, "p2": 3, "p3": 7], net: net)]), net: net)
+    
+    XCTAssertEqual(psEmpty.encodeMarkingSet([marking6, marking7]), [expectedPS1,expectedPS2])
+  }
+  
 //  func testSPS1() {
 //    typealias SPS = Set<PS<P,T>>
 //    enum P: Place {
 //      typealias Content = Int
-//      
+//
 //      case p1,p2,p3
 //    }
-//    
+//
 //    enum T: Transition {
 //      case t1//, t2
 //    }
-//    
+//
 //    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
 //    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
 //    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
 //    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
-//    
+//
 //    let ps1 = PS<P,T>.ps([marking1], [marking2])
 //    let ps2 = PS<P,T>.ps([marking3], [marking4])
-//    
+//
 //    XCTAssertEqual(PS<P,T>.union(sps1: [ps1], sps2: [.empty]), [ps1])
 //    XCTAssertEqual(PS<P,T>.intersection(sps1: [ps1], sps2: [ps2] , isCanonical: false), [PS.ps([marking1, marking3], [marking2, marking4])])
-//    
+//
 //    let ps3 = PS<P,T>.ps([marking2], [marking3])
-//    
+//
 //    let expectedSPS: SPS = [
 //      .ps([marking1, marking2], [marking2, marking3]),
 //      .ps([marking3, marking2], [marking3, marking4]),
 //    ]
-//    
+//
 //    XCTAssertEqual(PS.intersection(sps1: [ps1,ps2], sps2: [ps3], isCanonical: false), expectedSPS)
 //  }
-//  
+//
 //  func testSPS2() {
 //    typealias SPS = Set<PS<P,T>>
 //    enum P: Place {
 //      typealias Content = Int
-//      
+//
 //      case p1,p2
 //    }
-//    
+//
 //    enum T: Transition {
 //      case t1//, t2
 //    }
-//    
+//
 //    let marking1 = Marking<P>([.p1: 1, .p2: 2])
 //    let marking2 = Marking<P>([.p1: 3, .p2: 2])
 //    let marking3 = Marking<P>([.p1: 3, .p2: 0])
 //    let marking4 = Marking<P>([.p1: 5, .p2: 8])
 //    let sps: SPS = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
 //    let expectedSPS: SPS = [.ps([], [marking1, marking3]), .ps([marking4], [])]
-//    
+//
 //    XCTAssertEqual(PS.notSPS(sps: sps), expectedSPS)
 //  }
-//  
+//
 //  func testSPSObservator() {
 //    typealias SPS = Set<PS<P,T>>
 //    enum P: Place {
 //      typealias Content = Int
-//      
+//
 //      case p1,p2
 //    }
-//    
+//
 //    enum T: Transition {
 //      case t1//, t2
 //    }
-//    
+//
 //    var marking1 = Marking<P>([.p1: 4, .p2: 5])
 //    var marking2 = Marking<P>([.p1: 9, .p2: 10])
 //    var marking3 = Marking<P>([.p1: 3, .p2: 5])
@@ -147,7 +145,7 @@
 //    sps2 = [.ps([marking3], [marking4])]
 //    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,9)})}
 //    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: sps2))
-//    
+//
 //    marking4 = Marking<P>([.p1: 7, .p2: 7])
 //    let marking5 = Marking<P>([.p1: 6, .p2: 4])
 //    let marking6 = Marking<P>([.p1: 14, .p2: 11])
@@ -156,44 +154,44 @@
 //    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
 //    // ({(4,5)}, {(9,10)}) ∈ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
 //    XCTAssertTrue(PS.isIn(ps: .ps([marking1], [marking2]), sps: sps2))
-//    
+//
 //    // ∅ ⊆ {({(4,5)}, {(9,10)})}
 //    XCTAssertTrue(PS.isIncluded(sps1: [], sps2: sps1))
 //    // {({(4,5)}, {(9,10)})} ⊆ ∅
 //    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: []))
-//    
+//
 //    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps1))
-//    
+//
 //    marking1 = Marking<P>([.p1: 1, .p2: 2])
 //    marking2 = Marking<P>([.p1: 5, .p2: 8])
 //    marking3 = Marking<P>([.p1: 3, .p2: 0])
 //    marking4 = Marking<P>([.p1: 3, .p2: 2])
-//    
+//
 //    sps1 = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
 //    sps2 = [.ps([marking1], [marking4]), .ps([marking3], [marking2])]
 //
 //    // {({(1,2)}, {(5,8)}), ({(3,0)}, {(3,2)})} ≈ {({(1,2)}, {(3,2)}), ({(3,0)}, {(5,8)})}
 //    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps2))
-//    
+//
 //    let ps1: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 5, .p2: 5])])
 //    let ps2: PS<P,T> = .ps([Marking([.p1: 5, .p2: 5])], [Marking([.p1: 10, .p2: 7])])
 //    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 10, .p2: 7])])
 //
 //    XCTAssertTrue(PS.equiv(sps1: [ps1,ps2], sps2: [ps3]))
-//    
+//
 //    let ps4: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 8, .p2: 9])])
 //    let ps5: PS<P,T> = .ps([Marking([.p1: 7, .p2: 8])], [Marking([.p1: 10, .p2: 10])])
 //    let ps6: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 10, .p2: 10])])
 //    XCTAssertTrue(PS.equiv(sps1: [ps4,ps5], sps2: [ps6]))
-//    
+//
 //    let ps7: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [Marking([.p1: 4, .p2: 4])])
 //    let ps8: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [])
 //    let ps9: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [])
 //    let ps10: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 4, .p2: 4])])
-//    
+//
 //    XCTAssertTrue(PS.equiv(sps1: [ps7,ps8], sps2: [ps9,ps10]))
 //  }
-//  
+//
 //  func testRevertPS() {
 //    enum P: Place {
 //      typealias Content = Int
@@ -219,11 +217,11 @@
 //    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
 //    let revertT2 = Marking<P>([.p0: 2, .p1: 2])
 ////    print(model.fire(transition: .t1, from: marking1))
-//    
+//
 //    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t0, petrinet: model), PS.ps([revertT0], []))
 //    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t1, petrinet: model), PS.ps([revertT1], []))
 //    XCTAssertEqual(PS.revert(ps: .ps([marking1,marking2], []), transition: .t1, petrinet: model), PS.ps([revertT1, revertT2], []))
-//    print(model.revert(marking: marking2))    
+//    print(model.revert(marking: marking2))
 //  }
 //
 //  func testUnderlyingMarking() {
@@ -236,20 +234,20 @@
 //    enum T: Transition {
 //      case t0
 //    }
-//    
+//
 //    let pn = PetriNet<P, T>(
 //      .pre(from: .p0, to: .t0, labeled: 1),
 //      .post(from: .t0, to: .p1, labeled: 1),
 //      capacity: [.p0: 3, .p1: 3, .p2: 3]
 //    )
-//    
+//
 //    var ps: PS<P,T> = .ps([Marking([.p0: 0, .p1: 1, .p2: 0])], [Marking([.p0: 1, .p1: 1, .p2: 0]), Marking([.p0: 0, .p1: 2, .p2: 0]), Marking([.p0: 0, .p1: 1, .p2: 1])])
 //    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 1)
-//    
+//
 //    // 4*4*4
 //    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 0])], [])
 //    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 64)
-//    
+//
 //    // 4*4*3
 //    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 1])], [])
 //    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 48)
@@ -257,6 +255,6 @@
 //    ps = .ps([Marking([.p0: 0, .p1: 0, .p2: 2])], [Marking([.p0: 0, .p1: 0, .p2: 1])])
 //    XCTAssertEqual(ps.underlyingMarkings(petrinet: pn).count, 0)
 //  }
-//
-//  
-//}
+
+  
+}

--- a/Tests/PredicateStructureTests/PredicateStructureTests.swift
+++ b/Tests/PredicateStructureTests/PredicateStructureTests.swift
@@ -65,164 +65,159 @@ final class PredicateStructureTests: XCTestCase {
     XCTAssertEqual(psEmpty.encodeMarkingSet([marking6, marking7]), [expectedPS1,expectedPS2])
   }
   
-//  func testSPS1() {
-//    typealias SPS = Set<PS<P,T>>
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p1,p2,p3
-//    }
-//
-//    enum T: Transition {
-//      case t1//, t2
-//    }
-//
-//    let marking1 = Marking<P>([.p1: 4, .p2: 5, .p3: 6])
-//    let marking2 = Marking<P>([.p1: 1, .p2: 42, .p3: 2])
-//    let marking3 = Marking<P>([.p1: 3, .p2: 5, .p3: 6])
-//    let marking4 = Marking<P>([.p1: 0, .p2: 4, .p3: 0])
-//
-//    let ps1 = PS<P,T>.ps([marking1], [marking2])
-//    let ps2 = PS<P,T>.ps([marking3], [marking4])
-//
-//    XCTAssertEqual(PS<P,T>.union(sps1: [ps1], sps2: [.empty]), [ps1])
-//    XCTAssertEqual(PS<P,T>.intersection(sps1: [ps1], sps2: [ps2] , isCanonical: false), [PS.ps([marking1, marking3], [marking2, marking4])])
-//
-//    let ps3 = PS<P,T>.ps([marking2], [marking3])
-//
-//    let expectedSPS: SPS = [
-//      .ps([marking1, marking2], [marking2, marking3]),
-//      .ps([marking3, marking2], [marking3, marking4]),
-//    ]
-//
-//    XCTAssertEqual(PS.intersection(sps1: [ps1,ps2], sps2: [ps3], isCanonical: false), expectedSPS)
-//  }
-//
-//  func testSPS2() {
-//    typealias SPS = Set<PS<P,T>>
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p1,p2
-//    }
-//
-//    enum T: Transition {
-//      case t1//, t2
-//    }
-//
-//    let marking1 = Marking<P>([.p1: 1, .p2: 2])
-//    let marking2 = Marking<P>([.p1: 3, .p2: 2])
-//    let marking3 = Marking<P>([.p1: 3, .p2: 0])
-//    let marking4 = Marking<P>([.p1: 5, .p2: 8])
-//    let sps: SPS = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
-//    let expectedSPS: SPS = [.ps([], [marking1, marking3]), .ps([marking4], [])]
-//
-//    XCTAssertEqual(PS.notSPS(sps: sps), expectedSPS)
-//  }
-//
-//  func testSPSObservator() {
-//    typealias SPS = Set<PS<P,T>>
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p1,p2
-//    }
-//
-//    enum T: Transition {
-//      case t1//, t2
-//    }
-//
-//    var marking1 = Marking<P>([.p1: 4, .p2: 5])
-//    var marking2 = Marking<P>([.p1: 9, .p2: 10])
-//    var marking3 = Marking<P>([.p1: 3, .p2: 5])
-//    var marking4 = Marking<P>([.p1: 11, .p2: 10])
-//    var sps1: SPS = [.ps([marking1], [marking2])]
-//    var sps2: SPS = [.ps([marking3], [marking4])]
-//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,10)})}
-//    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
-//
-//    marking4 = Marking<P>([.p1: 11, .p2: 9])
-//    sps2 = [.ps([marking3], [marking4])]
-//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,9)})}
-//    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: sps2))
-//
-//    marking4 = Marking<P>([.p1: 7, .p2: 7])
-//    let marking5 = Marking<P>([.p1: 6, .p2: 4])
-//    let marking6 = Marking<P>([.p1: 14, .p2: 11])
-//    sps2 = [.ps([marking3], [marking4]), .ps([marking5], [marking6])]
-//    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
-//    XCTAssertTrue(PS.isIncluded(sps1: sps1, sps2: sps2))
-//    // ({(4,5)}, {(9,10)}) ∈ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
-//    XCTAssertTrue(PS.isIn(ps: .ps([marking1], [marking2]), sps: sps2))
-//
-//    // ∅ ⊆ {({(4,5)}, {(9,10)})}
-//    XCTAssertTrue(PS.isIncluded(sps1: [], sps2: sps1))
-//    // {({(4,5)}, {(9,10)})} ⊆ ∅
-//    XCTAssertFalse(PS.isIncluded(sps1: sps1, sps2: []))
-//
-//    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps1))
-//
-//    marking1 = Marking<P>([.p1: 1, .p2: 2])
-//    marking2 = Marking<P>([.p1: 5, .p2: 8])
-//    marking3 = Marking<P>([.p1: 3, .p2: 0])
-//    marking4 = Marking<P>([.p1: 3, .p2: 2])
-//
-//    sps1 = [.ps([marking1], [marking2]), .ps([marking3], [marking4])]
-//    sps2 = [.ps([marking1], [marking4]), .ps([marking3], [marking2])]
-//
-//    // {({(1,2)}, {(5,8)}), ({(3,0)}, {(3,2)})} ≈ {({(1,2)}, {(3,2)}), ({(3,0)}, {(5,8)})}
-//    XCTAssertTrue(PS.equiv(sps1: sps1, sps2: sps2))
-//
-//    let ps1: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 5, .p2: 5])])
-//    let ps2: PS<P,T> = .ps([Marking([.p1: 5, .p2: 5])], [Marking([.p1: 10, .p2: 7])])
-//    let ps3: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 10, .p2: 7])])
-//
-//    XCTAssertTrue(PS.equiv(sps1: [ps1,ps2], sps2: [ps3]))
-//
-//    let ps4: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 8, .p2: 9])])
-//    let ps5: PS<P,T> = .ps([Marking([.p1: 7, .p2: 8])], [Marking([.p1: 10, .p2: 10])])
-//    let ps6: PS<P,T> = .ps([Marking([.p1: 2, .p2: 3])], [Marking([.p1: 10, .p2: 10])])
-//    XCTAssertTrue(PS.equiv(sps1: [ps4,ps5], sps2: [ps6]))
-//
-//    let ps7: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [Marking([.p1: 4, .p2: 4])])
-//    let ps8: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [])
-//    let ps9: PS<P,T> = .ps([Marking([.p1: 4, .p2: 1])], [])
-//    let ps10: PS<P,T> = .ps([Marking([.p1: 1, .p2: 4])], [Marking([.p1: 4, .p2: 4])])
-//
-//    XCTAssertTrue(PS.equiv(sps1: [ps7,ps8], sps2: [ps9,ps10]))
-//  }
-//
-//  func testRevertPS() {
-//    enum P: Place {
-//      typealias Content = Int
-//
-//      case p0,p1
-//    }
-//
-//    enum T: Transition {
-//      case t0, t1
-//    }
-//
-//    let model = PetriNet<P, T>(
-//      .pre(from: .p0, to: .t0, labeled: 2),
-//      .post(from: .t0, to: .p0, labeled: 1),
-//      .post(from: .t0, to: .p1, labeled: 1),
-//      .pre(from: .p0, to: .t1, labeled: 1),
-//      .pre(from: .p1, to: .t1, labeled: 1)
-//    )
-//    let marking1 = Marking<P>([.p0: 0, .p1: 1])
-//    let marking2 = Marking<P>([.p0: 1, .p1: 1])
-//
-//    let revertT0 = Marking<P>([.p0: 2, .p1: 0])
-//    let revertT1 = Marking<P>([.p0: 1, .p1: 2])
-//    let revertT2 = Marking<P>([.p0: 2, .p1: 2])
-////    print(model.fire(transition: .t1, from: marking1))
-//
-//    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t0, petrinet: model), PS.ps([revertT0], []))
-//    XCTAssertEqual(PS.revert(ps: .ps([marking1], []), transition: .t1, petrinet: model), PS.ps([revertT1], []))
-//    XCTAssertEqual(PS.revert(ps: .ps([marking1,marking2], []), transition: .t1, petrinet: model), PS.ps([revertT1, revertT2], []))
-//    print(model.revert(marking: marking2))
-//  }
+  func testSPS1() {
+    typealias SPS = Set<PS>
+    
+    let net = PetriNet(
+      places: ["p1", "p2", "p3"],
+      transitions: ["t1"],
+      arcs: .pre(from: "p1", to: "t1", labeled: 2)
+    )
+
+    let marking1 = Marking(["p1": 4, "p2": 5, "p3": 6], net: net)
+    let marking2 = Marking(["p1": 1, "p2": 42,"p3": 2], net: net)
+    let marking3 = Marking(["p1": 3, "p2": 5, "p3": 6], net: net)
+    let marking4 = Marking(["p1": 0, "p2": 4, "p3": 0], net: net)
+
+    let ps1 = PS(ps: ([marking1], [marking2]), net: net)
+    let ps2 = PS(ps: ([marking3], [marking4]), net: net)
+
+    XCTAssertEqual(ps1.union(sps1: [ps1], sps2: [PS(ps: nil, net: net)]), [ps1])
+    XCTAssertEqual(ps1.intersection(sps1: [ps1], sps2: [ps2] , isCanonical: false), [PS(ps: ([marking1, marking3], [marking2, marking4]), net: net)])
+
+    let ps3 = PS(ps: ([marking2], [marking3]), net: net)
+
+    let expectedSPS: SPS = [
+      PS(ps: ([marking1, marking2], [marking2, marking3]), net: net),
+      PS(ps: ([marking3, marking2], [marking3, marking4]), net: net),
+    ]
+
+    XCTAssertEqual(ps1.intersection(sps1: [ps1,ps2], sps2: [ps3], isCanonical: false), expectedSPS)
+  }
+
+  func testSPS2() {
+    
+    typealias SPS = Set<PS>
+    
+    let net = PetriNet(
+      places: ["p1", "p2"],
+      transitions: ["t1"],
+      arcs: .pre(from: "p1", to: "t1", labeled: 2)
+    )
+
+    let marking1 = Marking(["p1": 1, "p2": 2], net: net)
+    let marking2 = Marking(["p1": 3, "p2": 2], net: net)
+    let marking3 = Marking(["p1": 3, "p2": 0], net: net)
+    let marking4 = Marking(["p1": 5, "p2": 8], net: net)
+    let sps: SPS = [PS(ps: ([marking1], [marking2]), net: net), PS(ps: ([marking3], [marking4]), net: net)]
+    let expectedSPS: SPS = [PS(ps: ([], [marking1, marking3]), net: net), PS(ps: ([marking4], []), net: net)]
+
+    let emptyPS = PS(ps: nil, net: net)
+    XCTAssertEqual(emptyPS.not(sps: sps), expectedSPS)
+  }
+
+  func testSPSObservator() {
+    
+    typealias SPS = Set<PS>
+    
+    let net = PetriNet(
+      places: ["p1", "p2"],
+      transitions: ["t1"],
+      arcs: .pre(from: "p1", to: "t1", labeled: 2)
+    )
+
+    var marking1 = Marking(["p1": 4, "p2": 5], net: net)
+    var marking2 = Marking(["p1": 9, "p2": 10], net: net)
+    var marking3 = Marking(["p1": 3, "p2": 5], net: net)
+    var marking4 = Marking(["p1": 11, "p2": 10], net: net)
+    var sps1: SPS = [PS(ps: ([marking1], [marking2]), net: net)]
+    var sps2: SPS = [PS(ps: ([marking3], [marking4]), net: net)]
+    
+    let emptyPS = PS(ps: nil, net: net)
+    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,10)})}
+    XCTAssertTrue(emptyPS.isIncluded(sps1: sps1, sps2: sps2))
+
+    marking4 = Marking(["p1": 11, "p2": 9], net: net)
+    sps2 = [PS(ps: ([marking3], [marking4]), net: net)]
+    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(11,9)})}
+    XCTAssertFalse(emptyPS.isIncluded(sps1: sps1, sps2: sps2))
+
+    marking4 = Marking(["p1": 7, "p2": 7], net: net)
+    let marking5 = Marking(["p1": 6, "p2": 4], net: net)
+    let marking6 = Marking(["p1": 14, "p2": 11], net: net)
+    sps2 = [PS(ps: ([marking3], [marking4]), net: net), PS(ps: ([marking5], [marking6]), net: net)]
+    // {({(4,5)}, {(9,10)})} ⊆ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
+    XCTAssertTrue(emptyPS.isIncluded(sps1: sps1, sps2: sps2))
+    // ({(4,5)}, {(9,10)}) ∈ {({(3,5)}, {(7,7)}), ({(6,4)}, {(14,11)})}
+    XCTAssertTrue(emptyPS.isIn(ps: PS(ps: ([marking1], [marking2]), net: net), sps: sps2))
+
+    // ∅ ⊆ {({(4,5)}, {(9,10)})}
+    XCTAssertTrue(emptyPS.isIncluded(sps1: [], sps2: sps1))
+    // {({(4,5)}, {(9,10)})} ⊆ ∅
+    XCTAssertFalse(emptyPS.isIncluded(sps1: sps1, sps2: []))
+
+    XCTAssertTrue(emptyPS.isEquiv(sps1: sps1, sps2: sps1))
+
+    marking1 = Marking(["p1": 1, "p2": 2], net: net)
+    marking2 = Marking(["p1": 5, "p2": 8], net: net)
+    marking3 = Marking(["p1": 3, "p2": 0], net: net)
+    marking4 = Marking(["p1": 3, "p2": 2], net: net)
+
+    sps1 = [PS(ps: ([marking1], [marking2]), net: net), PS(ps: ([marking3], [marking4]), net: net)]
+    sps2 = [PS(ps: ([marking1], [marking4]), net: net), PS(ps: ([marking3], [marking2]), net: net)]
+
+    // {({(1,2)}, {(5,8)}), ({(3,0)}, {(3,2)})} ≈ {({(1,2)}, {(3,2)}), ({(3,0)}, {(5,8)})}
+    XCTAssertTrue(emptyPS.isEquiv(sps1: sps1, sps2: sps2))
+
+    let ps1 = PS(ps: ([Marking(["p1": 1, "p2": 4], net: net)], [Marking(["p1": 5, "p2": 5], net: net)]), net: net)
+    let ps2 = PS(ps: ([Marking(["p1": 5, "p2": 5], net: net)], [Marking(["p1": 10, "p2": 7], net: net)]), net: net)
+    let ps3 = PS(ps: ([Marking(["p1": 1, "p2": 4], net: net)], [Marking(["p1": 10, "p2": 7], net: net)]), net: net)
+
+    XCTAssertTrue(emptyPS.isEquiv(sps1: [ps1,ps2], sps2: [ps3]))
+
+    let ps4 = PS(ps: ([Marking(["p1": 2, "p2": 3], net: net)], [Marking(["p1": 8, "p2": 9], net: net)]), net: net)
+    let ps5 = PS(ps: ([Marking(["p1": 7, "p2": 8], net: net)], [Marking(["p1": 10, "p2": 10], net: net)]), net: net)
+    let ps6 = PS(ps: ([Marking(["p1": 2, "p2": 3], net: net)], [Marking(["p1": 10, "p2": 10], net: net)]), net: net)
+    XCTAssertTrue(emptyPS.isEquiv(sps1: [ps4,ps5], sps2: [ps6]))
+
+    let ps7 = PS(ps: ([Marking(["p1": 4, "p2": 1], net: net)], [Marking(["p1": 4, "p2": 4], net: net)]), net: net)
+    let ps8 = PS(ps: ([Marking(["p1": 1, "p2": 4], net: net)], []), net: net)
+    let ps9 = PS(ps: ([Marking(["p1": 4, "p2": 1], net: net)], []), net: net)
+    let ps10 = PS(ps: ([Marking(["p1": 1, "p2": 4], net: net)], [Marking(["p1": 4, "p2": 4], net: net)]), net: net)
+
+    XCTAssertTrue(emptyPS.isEquiv(sps1: [ps7,ps8], sps2: [ps9,ps10]))
+  }
+
+  func testRevertPS() {
+
+    let net = PetriNet(
+      places: ["p0", "p1"],
+      transitions: ["t0", "t1"],
+      arcs: .pre(from: "p0", to: "t0", labeled: 2),
+      .post(from: "t0", to: "p0", labeled: 1),
+      .post(from: "t0", to: "p1", labeled: 1),
+      .pre(from: "p0", to: "t1", labeled: 1),
+      .pre(from: "p1", to: "t1", labeled: 1)
+    )
+    let marking1 = Marking(["p0": 0, "p1": 1], net: net)
+    let marking2 = Marking(["p0": 1, "p1": 1], net: net)
+
+    let revertT0 = Marking(["p0": 2, "p1": 0], net: net)
+    let revertT1 = Marking(["p0": 1, "p1": 2], net: net)
+    let revertT2 = Marking(["p0": 2, "p1": 2], net: net)
+//    print(model.fire(transition: .t1, from: marking1))
+    
+    let ps1 = PS(ps: ([marking1], []), net: net)
+    let ps2 = PS(ps: ([revertT0], []), net: net)
+    let ps3 = PS(ps: ([revertT1], []), net: net)
+    let ps4 = PS(ps: ([marking1, marking2], []), net: net)
+    let ps5 = PS(ps: ([revertT1, revertT2], []), net: net)
+
+    XCTAssertEqual(ps1.revert(transition: "t0"), ps2)
+    XCTAssertEqual(ps1.revert(transition: "t1"), ps3)
+    XCTAssertEqual(ps4.revert(transition: "t1"), ps5)
+    print(net.revert(marking: marking2))
+  }
 //
 //  func testUnderlyingMarking() {
 //    enum P: Place {


### PR DESCRIPTION
Big updates on the main version:

Place and Transition protocols have been deleted. There are not checked statically anymore. Information is directly contained inside Petri nets. All the code has been changed in this way, and simplified in other points.