### PR TITLE
Add saturation

### DIFF
--- a/Sources/SVSKit/PetriNet.swift
+++ b/Sources/SVSKit/PetriNet.swift
@@ -224,6 +224,17 @@ public class PetriNet
       matrix[arc.transition] = [arc.place: arc.label]
     }
   }
+  
+  public func createCapacityVectorBasedOnANat(n: Int) -> [PlaceType: Int] {
+    guard n >= 0 else {
+      fatalError("The capacity cannot be negative")
+    }
+    var storage: [String: Int] = [:]
+    for place in places {
+      storage[place] = n
+    }
+    return storage
+  }
 
 }
 
@@ -235,7 +246,7 @@ extension PetriNet {
   ///   - marking: The marking
   ///   - transition: The transition
   /// - Returns: The new marking after the revert firing.
-  public func revert(marking: Marking, transition: TransitionType) -> Marking? {
+  public func revert(marking: Marking, transition: TransitionType, capacity: [PlaceType: Int]) -> Marking? {
     var markingRes = marking
     for place in places {
       if let pre = input[transition]?[place] {
@@ -267,10 +278,10 @@ extension PetriNet {
   /// Apply the revert function for all transitions
   /// - Parameter marking: The marking
   /// - Returns: A set of markings that contains each new marking for each transition
-  public func revert(marking: Marking) -> Set<Marking> {
+  public func revert(marking: Marking, capacity: [PlaceType: Int]) -> Set<Marking> {
     var res: Set<Marking> = []
     for transition in transitions {
-      if let rev = revert(marking: marking, transition: transition) {
+      if let rev = revert(marking: marking, transition: transition, capacity: capacity) {
         res.insert(rev)
       }
     }
@@ -280,10 +291,10 @@ extension PetriNet {
   /// Apply the revert on a set of markings.
   /// - Parameter markings: The set of markings
   /// - Returns: The new sets of markings, which is a union of all revert firing for each marking.
-  public func revert(markings: Set<Marking>) -> Set<Marking> {
+  public func revert(markings: Set<Marking>, capacity: [PlaceType: Int]) -> Set<Marking> {
     var res: Set<Marking> = []
     for marking in markings {
-      res = res.union(revert(marking: marking))
+      res = res.union(revert(marking: marking, capacity: capacity))
     }
     return res
   }

--- a/Sources/SVSKit/SV.swift
+++ b/Sources/SVSKit/SV.swift
@@ -479,19 +479,19 @@ public struct SV {
   /// Compute the inverse of the fire operation for a given transition. It takes into account the current symbolic vector where it consumes tokens for post arcs and produces new ones for pre arcs.
   /// - Parameter transition: The given transition
   /// - Returns: A new symbolic vector where the revert operation has been applied.
-  public func revert(transition: String) -> SV? {
+  public func revert(transition: String, capacity: [PlaceType: Int]) -> SV? {
     if self.value == emptyValue {
       return self
     }
     
-    if let qaTemp = net.revert(marking: value.inc, transition: transition) {
+    if let qaTemp = net.revert(marking: value.inc, transition: transition, capacity: capacity) {
       var bTemp: Set<Marking> = []
       
       if value.exc == [] {
         bTemp = []
       } else {
         for marking in value.exc {
-          if let rev = net.revert(marking: marking, transition: transition) {
+          if let rev = net.revert(marking: marking, transition: transition, capacity: capacity) {
             bTemp.insert(rev)
           }
         }
@@ -503,7 +503,7 @@ public struct SV {
   
   /// General revert operation where all transitions are applied
   /// - Returns: A symbolic vector set resulting from the union of the revert operation on each transition on the current symbolic vector.
-  public func revert(canonicityLevel: CanonicityLevel) -> SVS {
+  public func revert(canonicityLevel: CanonicityLevel, capacity: [PlaceType: Int]) -> SVS {
     
 //    if let res = Memoization.memoizationRevertTable[self] {
 //      return res
@@ -511,7 +511,7 @@ public struct SV {
     
     var res: SVS = []
     for transition in net.transitions {
-      if let rev = self.revert(transition: transition)?.canonised() {
+      if let rev = self.revert(transition: transition, capacity: capacity)?.canonised() {
         if !rev.isEmpty() {
           res = res.add(rev, canonicityLevel: canonicityLevel)
         }

--- a/Sources/SVSKit/SVS.swift
+++ b/Sources/SVSKit/SVS.swift
@@ -293,7 +293,7 @@ public struct SVS {
   /// Compute the revert function on all markings of each symbolic vectors
   /// - Parameter canonicityLevel: The level of the canonicity
   /// - Returns: A new symbolic vector set after the revert application
-  public func revert(canonicityLevel: CanonicityLevel) -> SVS {
+  public func revert(canonicityLevel: CanonicityLevel, capacity: [String: Int]) -> SVS {
     
 //    if let res = Memoization.memoizationRevertTable[self] {
 //      return res
@@ -302,14 +302,14 @@ public struct SVS {
     if canonicityLevel == .none {
       var res: Set<SV> = []
       for sv in self {
-        res = res.union(sv.revert(canonicityLevel: canonicityLevel).values)
+        res = res.union(sv.revert(canonicityLevel: canonicityLevel, capacity: capacity).values)
       }
       return SVS(values: res)
     }
 
     var res: SVS = []
     for sv in self {
-      res = res.union(sv.revert(canonicityLevel: canonicityLevel), canonicityLevel: canonicityLevel)
+      res = res.union(sv.revert(canonicityLevel: canonicityLevel, capacity: capacity), canonicityLevel: canonicityLevel)
     }
     
 //    Memoization.memoizationRevertTable[self] = res
@@ -322,7 +322,7 @@ public struct SVS {
   ///   - net: The current Petri net
   ///   - canonicityLevel: The level of canonicity
   /// - Returns: A new symbolic vector set
-  public func revertTilde(net: PetriNet, canonicityLevel: CanonicityLevel) -> SVS {
+  public func revertTilde(net: PetriNet, canonicityLevel: CanonicityLevel, capacity: [String: Int]) -> SVS {
     
 //    if let res = Memoization.memoizationRevertTildeTable[self] {
 //      return res
@@ -334,7 +334,7 @@ public struct SVS {
     
     // AX Φ ≡ ¬ EX ¬ Φ
     let step1 = self.not(net: net, canonicityLevel: canonicityLevel)
-    let step2 = step1.revert(canonicityLevel: canonicityLevel)
+    let step2 = step1.revert(canonicityLevel: canonicityLevel, capacity: capacity)
     let step3 = step2.not(net: net, canonicityLevel: canonicityLevel)
     
 //    Memoization.memoizationRevertTildeTable[self] = step3

--- a/Tests/SVSKitTests/ListExampleTests.swift
+++ b/Tests/SVSKitTests/ListExampleTests.swift
@@ -62,11 +62,17 @@
 //    let parserPN = PnmlParser()
 //    let pnmlPath = resourcesDirectory + "SwimmingPool/SwimmingPool-1.pnml"
 //    
-//    let (net1, marking1) = parserPN.loadPN(filePath: pnmlPath)
+//    var (net1, marking1) = parserPN.loadPN(filePath: pnmlPath)
 //    print(net1)
 //    print(marking1)
 //    var s = Stopwatch()
 //
+//    var storage: [String: Int] = [:]
+//    for place in net1.places {
+//      storage[place] = 20
+//    }
+//    net1.capacity = storage
+//    
 //    let ctlPath = resourcesDirectory + "SwimmingPool/ReachabilityFireabilitySwimmingPool.xml"
 //    let parserCTL = CTLParser()
 //    let dicCTL = parserCTL.loadCTL(filePath: ctlPath)
@@ -348,7 +354,7 @@
 //    let (net1, marking1) = parserPN.loadPN(filePath: pnmlPath)
 //    var s = Stopwatch()
 //
-//    let ctlPath = resourcesDirectory + "ERK/ERK-CTLFireability.xml"
+//    let ctlPath = resourcesDirectory + "ERK/ERK-ReachabilityFireability.xml"
 //    let parserCTL = CTLParser()
 //    let dicCTL = parserCTL.loadCTL(filePath: ctlPath)
 //
@@ -443,7 +449,7 @@
 //        print("Query: \(ctlReduced)")
 //        s.reset()
 ////        answers[key] = ctlReduced.eval(marking: marking1)
-////        answers[key] = ctlReduced.eval()
+//        answers[key] = ctlReduced.eval()
 ////        print(answers[key]!)
 //        times[key] = s.elapsed.humanFormat
 //        print(s.elapsed.humanFormat)
@@ -498,31 +504,40 @@
 //  
 //  func testCircadianClock() {
 //    let parserPN = PnmlParser()
-//    let pnmlPath = resourcesDirectory + "CircadianClock-PT-000001/model.pnml"
-//    let (net1, marking1) = parserPN.loadPN(filePath: pnmlPath)
+//    let pnmlPath = resourcesDirectory + "CircadianClock-PT-000010/model.pnml"
+//    var (net1, marking1) = parserPN.loadPN(filePath: pnmlPath)
 //    var s = Stopwatch()
 //
-//    let ctlPath = resourcesDirectory + "CircadianClock-PT-000001/ReachabilityFireability.xml"
+//    let ctlPath = resourcesDirectory + "CircadianClock-PT-000010/ReachabilityFireability.xml"
 //    let parserCTL = CTLParser()
-//    let dicCTL = parserCTL.loadCTL(filePath: ctlPath)
+//    var dicCTL = parserCTL.loadCTL(filePath: ctlPath)
+//    
+//    dicCTL.removeValue(forKey: "CircadianClock-PT-000010-ReachabilityFireability-03")
 //    
 //    s.reset()
+//    
+//    var storage: [String: Int] = [:]
+//    for place in net1.places {
+//      storage[place] = 10
+//    }
+//    net1.capacity = storage
 //
-////    var answers: [String: Bool] = [:]
-//    var answers: [String: SVS] = [:]
+//    var answers: [String: Bool] = [:]
+////    var answers: [String: SVS] = [:]
 //    var times: [String: String] = [:]
 //    for (key, formula) in dicCTL.sorted(by: {$0.key < $1.key}) {
-//      let ctlReduced = CTL(formula: formula, net: net1, canonicityLevel: .full, simplified: false, debug: false).queryReduction()
+//      let ctlReduced = CTL(formula: formula, net: net1, canonicityLevel: .full, simplified: false, debug: true).queryReduction()
 //      print("-------------------------------")
 //      print(key)
-//      answers[key] = ctlReduced.eval()
+////      answers[key] = ctlReduced.eval()
 //      s.reset()
-//      print("Nb sv: \(answers[key]!.count)")
-//      print("Nb markings Expected: \(answers[key]!.underlyingMarkings().count)")
-//      print("Nb markings formula: \(answers[key]!.nbOfMarkings())")
+//      answers[key] = ctlReduced.eval(marking: marking1)
+////      print("Nb sv: \(answers[key]!.count)")
+////      print("Nb markings Expected: \(answers[key]!.underlyingMarkings().count)")
+////      print("Nb markings formula: \(answers[key]!.nbOfMarkings())")
 ////      print(answers[key]!)
 //      times[key] = s.elapsed.humanFormat
-//      print(s.elapsed.humanFormat)
+//      print(times[key]!)
 //      print("-------------------------------")
 //    }
 //
@@ -531,30 +546,25 @@
 ////    var count = 0
 //    
 //    for (key, b) in answers.sorted(by: {$0.key < $1.key}) {
-////      print("Formula \(key) is: \(b) (\(times[key]!))")
-//      print("Formula \(key) is: \(times[key]!)")
-//      print("Nb of sv: \(answers[key]!.count)")
-//      svNumbers.append(answers[key]!.count)
-//      for sv in answers[key]! {
-////        count += 1
-//        markingNumbers.append(1 + sv.value.exc.count)
-//      }
+//      print("Formula \(key) is: \(b) (\(times[key]!))")
+////      print("Formula \(key) is: \(times[key]!)")
+////      print("Nb of sv: \(answers[key]!.count)")
 //    }
 //
 //    let avgMarking = Double(markingNumbers.reduce(0, {$0+$1})) / Double(markingNumbers.count)
 //    let avgSV = Double(svNumbers.reduce(0, {$0+$1})) / Double(svNumbers.count)
 //  
-//    print("Nb average SV: \(avgSV)")
-//    print("Nb average marking: \(avgMarking)")
-//    print("Std sv: \(standardDeviationInt(seq: svNumbers))")
-//    print("Std marking: \(standardDeviationInt(seq: markingNumbers))")
+////    print("Nb average SV: \(avgSV)")
+////    print("Nb average marking: \(avgMarking)")
+////    print("Std sv: \(standardDeviationInt(seq: svNumbers))")
+////    print("Std marking: \(standardDeviationInt(seq: markingNumbers))")
 //  }
 //  
 ////  func evalEF(formula: Formula) -> SVS {
 ////    let phi = CTL(formula: formula, net: net, canonicityLevel: canonicityLevel)
 ////    var res = phi
 ////    var resTemp: SVS
-////    
+////
 ////    var newNet = net
 ////    var storage: [String: Int] = [:]
 ////    for i in 1 ..< net.capacity.first!.value + 1 {
@@ -562,7 +572,7 @@
 ////        storage[place] = i
 ////      }
 ////      newNet.capacity = storage
-////      
+////
 ////    }
 ////  }
 //  
@@ -576,31 +586,22 @@
 //    let parserCTL = CTLParser()
 //    let dicCTL = parserCTL.loadCTL(filePath: ctlPath)
 //    
+////    let key = "CircadianClock-PT-000001-ReachabilityFireability-14"
 //    let key = "CircadianClock-PT-000001-ReachabilityFireability-14"
-//    let ctlReduced = CTL(formula: dicCTL[key]!, net: net1, canonicityLevel: .full, simplified: false, debug: true).queryReduction()
 //      
-//    s.reset()
-//    let r1 = ctlReduced.eval()
-//    print(s.elapsed.humanFormat)
-//    
-//    var storage: [String: Int] = [:]
-//    for place in net1.places {
-//      storage[place] = 2
+//    for i in 4 ..< 5 {
+//      var storage: [String: Int] = [:]
+//      for place in net1.places {
+//        storage[place] = i
+//      }
+//      var net = net1
+//      net.capacity = storage
+//      let ctlReduced = CTL(formula: dicCTL[key]!, net: net, canonicityLevel: .full, simplified: false, saturated: false, debug: true).queryReduction()
+//      s.reset()
+//      print(i)
+//      let r = ctlReduced.eval()
+//      print(s.elapsed.humanFormat)
 //    }
-//    net1.capacity = storage
-//    s.reset()
-//    let r2 = ctlReduced.eval()
-//    print(s.elapsed.humanFormat)
-//    print("Are r1 and r2 equal ? \(r1 == r2)")
-//    
-//    for place in net1.places {
-//      storage[place] = 3
-//    }
-//    net1.capacity = storage
-//    s.reset()
-//    let r3 = ctlReduced.eval()
-//    print(s.elapsed.humanFormat)
-//    print("Are r1 and r3 equal ? \(r1 == r3)")
 //  }
 //  
 //}

--- a/Tests/SVSKitTests/PetriNetTests.swift
+++ b/Tests/SVSKitTests/PetriNetTests.swift
@@ -19,10 +19,10 @@ final class PetriNetTests: XCTestCase {
     let marking = Marking(["p0": 0, "p1": 1], net: pn)
     let revertT0 = Marking(["p0": 2, "p1": 0], net: pn)
     let revertT1 = Marking(["p0": 1, "p1": 2], net: pn)
-    XCTAssertEqual(pn.revert(marking: marking, transition: "t0"), revertT0)
-    XCTAssertEqual(pn.revert(marking: marking, transition: "t1"), revertT1)
-    XCTAssertEqual(pn.revert(marking: marking), [revertT0, revertT1])
-    XCTAssertEqual(pn.revert(markings: [marking]), [revertT0, revertT1])
+    XCTAssertEqual(pn.revert(marking: marking, transition: "t0", capacity: pn.capacity), revertT0)
+    XCTAssertEqual(pn.revert(marking: marking, transition: "t1", capacity: pn.capacity), revertT1)
+    XCTAssertEqual(pn.revert(marking: marking, capacity: pn.capacity), [revertT0, revertT1])
+    XCTAssertEqual(pn.revert(markings: [marking], capacity: pn.capacity), [revertT0, revertT1])
   }
   
   func testCapacity() {

--- a/Tests/SVSKitTests/SVTests.swift
+++ b/Tests/SVSKitTests/SVTests.swift
@@ -186,9 +186,9 @@ final class SVTests: XCTestCase {
     let ps4 = SV(value: ([marking1, marking2], []), net: net)
     let ps5 = SV(value: ([revertT1, revertT2], []), net: net)
 
-    XCTAssertEqual(ps1.revert(transition: "t0"), ps2)
-    XCTAssertEqual(ps1.revert(transition: "t1"), ps3)
-    XCTAssertEqual(ps4.revert(transition: "t1"), ps5)
+    XCTAssertEqual(ps1.revert(transition: "t0", capacity: net.capacity), ps2)
+    XCTAssertEqual(ps1.revert(transition: "t1", capacity: net.capacity), ps3)
+    XCTAssertEqual(ps4.revert(transition: "t1", capacity: net.capacity), ps5)
   }
 
   func testUnderlyingMarking() {


### PR DESCRIPTION
The saturation is a mechanism used to facilitate the computation of the fixed-point. Symbolic vectors are closely tied to the place capacities of a Petri net, specifically, the maximum number of tokens per place. As the capacity increases, the computation becomes more complex due to the growing number of possibilities to consider. Nevertheless, the final solution can remain the same, even when the capacity is increased.

The approach involves iteratively computing each step of the fixed point for each place's capacity. If we need to compute a place capacity of 10 for each place, we begin with 1 and then proceed to 2, and so on. By following this method, each cardinality generates a complete set of valid solutions, which can be reused in subsequent steps to expedite convergence. The fixed-point iteration is then minimized to the lowest possible cardinality to obtain the corresponding solution.